### PR TITLE
CI/CD: Refactor workflow for correct job names, single deploy, and main/PR logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI/CD Pipeline
 
 on:
-  push:
-    branches: [ main, develop ]
   pull_request:
+    branches: [ main ]
+  push:
     branches: [ main ]
 
 env:
@@ -11,160 +11,145 @@ env:
   DOCKER_IMAGE: petrosa/ta-bot
 
 jobs:
-  lint:
+  lint-test:
+    if: github.event_name == 'pull_request'
+    name: Lint & Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-    
-    - name: Run linting
-      run: |
-        black --check ta_bot/ tests/
-        flake8 ta_bot/ tests/ --max-line-length=88 --ignore=E203,W503
-        mypy ta_bot/ --ignore-missing-imports
-        ruff check ta_bot/ tests/
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run linting
+        run: |
+          black --check ta_bot/ tests/
+          flake8 ta_bot/ tests/ --max-line-length=88 --ignore=E203,W503
+          mypy ta_bot/ --ignore-missing-imports
+          ruff check ta_bot/ tests/
+      - name: Run tests with coverage
+        run: |
+          python -m pytest tests/ --cov=ta_bot --cov-report=xml --cov-report=html --cov-fail-under=50
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
 
-  test:
+  security-scan:
+    if: github.event_name == 'pull_request'
+    name: Security Scan
     runs-on: ubuntu-latest
-    needs: lint
+    needs: lint-test
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-    
-    - name: Run tests with coverage
-      run: |
-        python -m pytest tests/ --cov=ta_bot --cov-report=xml --cov-report=html --cov-fail-under=50
-    
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run security scans
+        run: |
+          bandit -r ta_bot/ -f json -o bandit-report.json || true
+          safety check --json --output safety-report.json || true
+      - name: Install Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
 
-  security:
+  create-release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: Create Release
     runs-on: ubuntu-latest
-    needs: test
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-    
-    - name: Run security scans
-      run: |
-        bandit -r ta_bot/ -f json -o bandit-report.json || true
-        safety check --json --output safety-report.json || true
-    
-    - name: Install Trivy
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-    
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
-      if: always()
-      with:
-        sarif_file: 'trivy-results.sarif'
+      - uses: actions/checkout@v4
+      - name: Create Release Tag
+        run: |
+          echo "v$(date +'%Y.%m.%d.%H%M%S')" > release_tag.txt
+          git tag $(cat release_tag.txt)
+          git push origin $(cat release_tag.txt)
 
-  build:
+  build-push:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: Build & Push
     runs-on: ubuntu-latest
-    needs: security
+    needs: create-release
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    
-    - name: Build Docker image
-      run: |
-        docker build -t ${{ env.DOCKER_IMAGE }}:${{ github.sha }} .
-        docker build -t ${{ env.DOCKER_IMAGE }}:latest .
-    
-    - name: Run container tests
-      run: |
-        docker run --rm ${{ env.DOCKER_IMAGE }}:${{ github.sha }} python -c "import ta_bot; print('TA Bot imported successfully')" || echo "Container test failed but continuing"
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        run: |
+          docker build -t ${{ env.DOCKER_IMAGE }}:${{ github.sha }} .
+          docker build -t ${{ env.DOCKER_IMAGE }}:latest .
+      - name: Run container tests
+        run: |
+          docker run --rm ${{ env.DOCKER_IMAGE }}:${{ github.sha }} python -c "import ta_bot; print('TA Bot imported successfully')" || echo "Container test failed but continuing"
+      - name: Push Docker image
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker push ${{ env.DOCKER_IMAGE }}:${{ github.sha }}
+          docker push ${{ env.DOCKER_IMAGE }}:latest
 
-  deploy-staging:
+  deploy-to-kubernetes:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: Deploy to Kubernetes
     runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/develop'
-    environment: staging
+    needs: build-push
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up kubectl
-      uses: azure/setup-kubectl@v3
-      with:
-        version: 'latest'
-    
-    - name: Configure kubectl
-      run: |
-        echo "${{ secrets.KUBECONFIG }}" | base64 -d > k8s/kubeconfig.yaml
-        export KUBECONFIG=k8s/kubeconfig.yaml
-    
-    - name: Deploy to staging
-      run: |
-        export KUBECONFIG=k8s/kubeconfig.yaml
-        kubectl apply -f k8s/ || echo "Deployment failed but continuing"
-        kubectl set image deployment/petrosa-ta-bot ta-bot=${{ env.DOCKER_IMAGE }}:${{ github.sha }} -n petrosa-apps || echo "Image update failed but continuing"
-        kubectl rollout status deployment/petrosa-ta-bot -n petrosa-apps || echo "Rollout status check failed but continuing"
+      - uses: actions/checkout@v4
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'latest'
+      - name: Configure kubectl
+        run: |
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > k8s/kubeconfig.yaml
+          export KUBECONFIG=k8s/kubeconfig.yaml
+      - name: Deploy to Kubernetes
+        run: |
+          export KUBECONFIG=k8s/kubeconfig.yaml
+          kubectl apply -f k8s/ || echo "Deployment failed but continuing"
+          kubectl set image deployment/petrosa-ta-bot ta-bot=${{ env.DOCKER_IMAGE }}:${{ github.sha }} -n petrosa-apps || echo "Image update failed but continuing"
+          kubectl rollout status deployment/petrosa-ta-bot -n petrosa-apps || echo "Rollout status check failed but continuing"
+      - name: Verify deployment
+        run: |
+          export KUBECONFIG=k8s/kubeconfig.yaml
+          kubectl get pods -n petrosa-apps -l app=petrosa-ta-bot || echo "Pod verification failed but continuing"
+          kubectl get svc -n petrosa-apps -l app=petrosa-ta-bot || echo "Service verification failed but continuing"
 
-  deploy-production:
+  cleanup:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: cleanup
     runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    environment: production
+    needs: deploy-to-kubernetes
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up kubectl
-      uses: azure/setup-kubectl@v3
-      with:
-        version: 'latest'
-    
-    - name: Configure kubectl
-      run: |
-        echo "${{ secrets.KUBECONFIG }}" | base64 -d > k8s/kubeconfig.yaml
-        export KUBECONFIG=k8s/kubeconfig.yaml
-    
-    - name: Deploy to production
-      run: |
-        export KUBECONFIG=k8s/kubeconfig.yaml
-        kubectl apply -f k8s/ || echo "Deployment failed but continuing"
-        kubectl set image deployment/petrosa-ta-bot ta-bot=${{ env.DOCKER_IMAGE }}:${{ github.sha }} -n petrosa-apps || echo "Image update failed but continuing"
-        kubectl rollout status deployment/petrosa-ta-bot -n petrosa-apps || echo "Rollout status check failed but continuing"
-    
-    - name: Verify deployment
-      run: |
-        export KUBECONFIG=k8s/kubeconfig.yaml
-        kubectl get pods -n petrosa-apps -l app=petrosa-ta-bot || echo "Pod verification failed but continuing"
-        kubectl get svc -n petrosa-apps -l app=petrosa-ta-bot || echo "Service verification failed but continuing" 
+      - name: Cleanup Docker images
+        run: |
+          docker system prune -af || true
+
+  notify:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: notify
+    runs-on: ubuntu-latest
+    needs: deploy-to-kubernetes
+    steps:
+      - name: Notify Success
+        run: |
+          echo "Deployment to Kubernetes complete!" 


### PR DESCRIPTION
- Use job names consistent with the rest of the service (Lint & Test, Security Scan, Create Release, Build & Push, Deploy to Kubernetes, cleanup, notify)
- Only run lint/test/security on PRs
- Only build and deploy on main push
- Remove deploy-staging/production split; use a single deploy job
- Clean up and notify jobs after deploy

This brings the workflow in line with the conventions and requirements for this repo.