### PR TITLE
CI/CD: Use DockerHub username for image name and workflow improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: '3.11'
-  DOCKER_IMAGE: petrosa/ta-bot
+  DOCKER_IMAGE: ${{ secrets.DOCKER_USERNAME }}/ta-bot
 
 jobs:
   lint-test:


### PR DESCRIPTION
- Set DOCKER_IMAGE to use DockerHub username from secrets
- All image references now use secrets.DOCKER_USERNAME/ta-bot
- Refactored workflow for correct job names, single deploy, and main/PR logic

This PR fixes the deploy pipeline image name and aligns the workflow with repo conventions.