### PR TITLE
fix: close all if/else blocks in notify job to resolve shell syntax error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
           echo "❌ Deployment failed!"
           echo "📦 Version: ${VERSION}"
           echo "🐳 Image Tag: ${IMAGE_TAG}"
+        fi
 
   cleanup:
     name: cleanup


### PR DESCRIPTION
This PR fixes a shell script error in the notify job by properly closing all if/else blocks. The notify step will now complete without syntax errors.