### PR TITLE
fix: use global NATS_URL, TA_BOT_ prefix for app config, and dynamic version label

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: petrosa-apps
   labels:
     app: petrosa-ta-bot
-    version: v1.0.0
+    version: VERSION_PLACEHOLDER
 spec:
   replicas: 3
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app: petrosa-ta-bot
-        version: v1.0.0
+        version: VERSION_PLACEHOLDER
     spec:
       containers:
       - name: ta-bot
@@ -28,33 +28,33 @@ spec:
         - name: NATS_URL
           valueFrom:
             configMapKeyRef:
-              name: ta-bot-config
-              key: nats_url
-        - name: API_ENDPOINT
+              name: petrosa-global-config
+              key: NATS_URL
+        - name: TA_BOT_API_ENDPOINT
           valueFrom:
             configMapKeyRef:
-              name: ta-bot-config
-              key: api_endpoint
-        - name: LOG_LEVEL
+              name: petrosa-common-config
+              key: TA_BOT_API_ENDPOINT
+        - name: TA_BOT_LOG_LEVEL
           valueFrom:
             configMapKeyRef:
-              name: ta-bot-config
-              key: log_level
-        - name: ENVIRONMENT
+              name: petrosa-common-config
+              key: TA_BOT_LOG_LEVEL
+        - name: TA_BOT_ENVIRONMENT
           valueFrom:
             configMapKeyRef:
-              name: ta-bot-config
-              key: environment
-        - name: SUPPORTED_SYMBOLS
+              name: petrosa-common-config
+              key: TA_BOT_ENVIRONMENT
+        - name: TA_BOT_SUPPORTED_SYMBOLS
           valueFrom:
             configMapKeyRef:
-              name: ta-bot-config
-              key: supported_symbols
-        - name: SUPPORTED_TIMEFRAMES
+              name: petrosa-common-config
+              key: TA_BOT_SUPPORTED_SYMBOLS
+        - name: TA_BOT_SUPPORTED_TIMEFRAMES
           valueFrom:
             configMapKeyRef:
-              name: ta-bot-config
-              key: supported_timeframes
+              name: petrosa-common-config
+              key: TA_BOT_SUPPORTED_TIMEFRAMES
         resources:
           requests:
             memory: "256Mi"

--- a/ta_bot/config.py
+++ b/ta_bot/config.py
@@ -15,11 +15,11 @@ class Config:
     nats_url: str = os.getenv("NATS_URL", "nats://localhost:4222")
 
     # API Configuration
-    api_endpoint: str = os.getenv("API_ENDPOINT", "http://localhost:8080/signals")
+    api_endpoint: str = os.getenv("TA_BOT_API_ENDPOINT", "http://localhost:8080/signals")
 
     # Optional settings with defaults
-    log_level: str = "INFO"
-    environment: str = "production"
+    log_level: str = os.getenv("TA_BOT_LOG_LEVEL", "INFO")
+    environment: str = os.getenv("TA_BOT_ENVIRONMENT", "production")
     health_check_interval: int = 30
     max_retries: int = 3
     timeout: int = 30


### PR DESCRIPTION
This PR:
- Uses global NATS_URL (no prefix, from petrosa-global-config)
- Uses TA_BOT_ prefix for all TA bot–specific config (from petrosa-common-config)
- Removes all hardcoded version labels and uses VERSION_PLACEHOLDER for dynamic CI/CD replacement
- Ensures full compliance with repo and deployment rules.