### PR TITLE
Fix health server shutdown handling to prevent crashes

### DIFF
--- a/ta_bot/health.py
+++ b/ta_bot/health.py
@@ -110,7 +110,13 @@ class HealthServerRunner:
     async def start(self):
         """Start the health server."""
         logger.info("Health server started")
-        await self.server.serve()
+        try:
+            await self.server.serve()
+        except asyncio.CancelledError:
+            logger.info("Health server shutdown requested")
+        except Exception as e:
+            logger.error(f"Health server error: {e}")
+            raise
 
     async def stop(self):
         """Stop the health server."""


### PR DESCRIPTION
This PR fixes the health server shutdown handling to prevent crashes when the container is terminated.