### PR TITLE
Fix NATS subject subscription to match extractor publishing format

### DIFF
--- a/ta_bot/config.py
+++ b/ta_bot/config.py
@@ -40,7 +40,7 @@ class Config:
 
     # Technical analysis settings
     candle_periods: List[str] = field(
-        default_factory=lambda: os.getenv("SUPPORTED_TIMEFRAMES", "15m,1h").split(",")
+        default_factory=lambda: os.getenv("SUPPORTED_TIMEFRAMES", "5m").split(",")
     )
     symbols: List[str] = field(
         default_factory=lambda: os.getenv("SUPPORTED_SYMBOLS", "BTCUSDT,ETHUSDT,ADAUSDT").split(",")

--- a/ta_bot/services/nats_listener.py
+++ b/ta_bot/services/nats_listener.py
@@ -51,8 +51,8 @@ class NATSListener:
 
             for symbol in self.supported_symbols:
                 for timeframe in self.supported_timeframes:
-                    # Use the production subject prefix for candle data
-                    subject = f"{self.nats_subject_prefix_production}.{symbol}.{timeframe}"
+                    # Use the production subject prefix for candle data with klines
+                    subject = f"{self.nats_subject_prefix_production}.klines.{symbol}.{timeframe}"
                     sub = await self.nc.subscribe(
                         subject, cb=self._handle_candle_message
                     )


### PR DESCRIPTION
This PR fixes the NATS subject subscription to match what the binance extractors are actually publishing:

## Key Changes:

1. **Added 'klines' to subject format**: 
   - Changed from: 
   - Changed to: 

2. **Updated default timeframe to 5m**:
   - Changed from: 
   - Changed to: 
   - This matches what the extractors are publishing

## Expected Behavior:

The TA bot will now:
- Subscribe to: 
- Receive messages from extractors publishing to the same subjects
- Log all received NATS messages as requested

This ensures the TA bot subscribes to the correct subjects that the binance extractors are actually publishing.