### PR TITLE
CRITICAL FIX: Restore VERSION_PLACEHOLDER in deployment.yaml

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: ta-bot
-        image: yurisa2/petrosa-ta-bot:v1.0.19
+        image: yurisa2/petrosa-ta-bot:VERSION_PLACEHOLDER
         imagePullPolicy: Always
         ports:
         - containerPort: 8000


### PR DESCRIPTION
⚠️ This PR fixes a critical violation of CI/CD pipeline rules

## Issue
- I manually changed VERSION_PLACEHOLDER to v1.0.19/v1.0.20
- This violates the critical rule: VERSION_PLACEHOLDER MUST NEVER BE MANUALLY CHANGED
- Manual changes break the automated CI/CD version management system

## Fix
- Restored VERSION_PLACEHOLDER in image tag (line 22)
- CI/CD pipeline automatically replaces it with actual version tags
- This ensures the automated version management continues to work

## Impact
- Prevents CI/CD pipeline failures
- Maintains automated version bumping
- Ensures consistent version management across deployments

This is a critical fix to maintain the integrity of the CI/CD pipeline.