### PR TITLE
Add debug logging for repr of password and database name

### DIFF
--- a/ta_bot/services/mysql_client.py
+++ b/ta_bot/services/mysql_client.py
@@ -76,6 +76,8 @@ class MySQLClient:
             logger.info(f"  User: {self.user}")
             logger.info(f"  Database: {self.database}")
             logger.info(f"  Password: {'***' if self.password else 'None'}")
+            logger.info(f"  Database repr: {repr(self.database)}")
+            logger.info(f"  Password repr: {repr(self.password)}")
             
             self.connection = pymysql.connect(
                 host=self.host,


### PR DESCRIPTION
This PR adds debug logging to print the repr of the password and database name used for MySQL connection. This will help diagnose if there are invisible or encoded characters causing authentication issues, even though the extractor pods work with the same URI.