### PR TITLE
Add debug logging to __init__ method to trace URI parsing

### DIFF
--- a/ta_bot/services/mysql_client.py
+++ b/ta_bot/services/mysql_client.py
@@ -21,16 +21,25 @@ class MySQLClient:
         """Initialize MySQL client."""
         # Try to get URI from environment first
         mysql_uri = os.getenv("MYSQL_URI")
+        logger.info(f"Raw MYSQL_URI from environment: {mysql_uri}")
         
         if mysql_uri:
             # Parse the URI - handle mysql+pymysql:// protocol
             if mysql_uri.startswith('mysql+pymysql://'):
                 # Remove the mysql+pymysql:// prefix for parsing
                 uri_for_parsing = mysql_uri.replace('mysql+pymysql://', 'mysql://')
+                logger.info(f"Converted URI for parsing: {uri_for_parsing}")
             else:
                 uri_for_parsing = mysql_uri
                 
             parsed_uri = urlparse(uri_for_parsing)
+            logger.info(f"Parsed URI components:")
+            logger.info(f"  hostname: {parsed_uri.hostname}")
+            logger.info(f"  port: {parsed_uri.port}")
+            logger.info(f"  username: {parsed_uri.username}")
+            logger.info(f"  password: {'***' if parsed_uri.password else 'None'}")
+            logger.info(f"  path: {parsed_uri.path}")
+            
             self.host = parsed_uri.hostname
             self.port = parsed_uri.port or 3306
             self.user = parsed_uri.username
@@ -39,8 +48,10 @@ class MySQLClient:
             self.database = parsed_uri.path.lstrip('/')
             if '%' in self.database:
                 from urllib.parse import unquote
+                original_db = self.database
                 self.database = unquote(self.database)
-            logger.info(f"Parsed MySQL URI: {self.host}:{self.port}/{self.database}")
+                logger.info(f"URL decoded database name: '{original_db}' -> '{self.database}'")
+            logger.info(f"Final parsed MySQL URI: {self.host}:{self.port}/{self.database}")
         elif uri:
             # Use provided URI
             if uri.startswith('mysql+pymysql://'):


### PR DESCRIPTION
This PR adds debug logging to the MySQL client __init__ method to trace the URI parsing process. This will help us see exactly how the MYSQL_URI is being parsed and identify any issues with the parsing logic that might be causing authentication problems.