### PR TITLE
Fix database schema: use correct column names

### DIFF
--- a/ta_bot/services/mysql_client.py
+++ b/ta_bot/services/mysql_client.py
@@ -118,7 +118,7 @@ class MySQLClient:
 
             # Build SQL query
             sql = f"""
-                SELECT timestamp, open, high, low, close, volume
+                SELECT timestamp, open_price as open, high_price as high, low_price as low, close_price as close, volume
                 FROM {table_name}
                 WHERE symbol = %s
                 ORDER BY timestamp DESC


### PR DESCRIPTION
Fix SQL query to use correct column names that match the actual database schema: open_price, high_price, low_price, close_price instead of open, high, low, close