### PR TITLE
feat: implement VERSION_PLACEHOLDER compliance across all Kubernetes manifests

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: petrosa-apps
   labels:
     app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
 data:
   api_endpoint: "http://petrosa-tradeengine-service/trade/signal"
   rsi_period: "14"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: petrosa-apps
   labels:
     app: petrosa-ta-bot
-    version: latest
+    version: VERSION_PLACEHOLDER
 spec:
   replicas: 3
   selector:
@@ -15,11 +15,11 @@ spec:
     metadata:
       labels:
         app: petrosa-ta-bot
-        version: local-20250818-224756-0f0c993
+        version: VERSION_PLACEHOLDER
     spec:
       containers:
       - name: ta-bot
-        image: yurisa2/petrosa-ta-bot:latest
+        image: yurisa2/petrosa-ta-bot:VERSION_PLACEHOLDER
         imagePullPolicy: Always
         ports:
         - containerPort: 8000

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: petrosa-apps
   labels:
     app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: petrosa-apps
   labels:
     app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
   annotations:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: petrosa-apps
   labels:
     app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
 spec:
   podSelector:
     matchLabels:

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: petrosa-apps
   labels:
     app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
 type: Opaque
 data:
   # Base64 encoded secrets - replace with actual values

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: petrosa-apps
   labels:
     app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
 spec:
   selector:
     app: petrosa-ta-bot


### PR DESCRIPTION
## Changes Made

- Replace hardcoded versions (latest, local-*) with VERSION_PLACEHOLDER
- Add version labels to all Kubernetes resources for consistency
- Update deployment.yaml, service.yaml, ingress.yaml, hpa.yaml
- Update network-policy.yaml, configmap.yaml, secrets.yaml
- Ensure compliance with Petrosa auto-increment system
- Enable seamless integration with CI/CD pipelines and version management

## Files Changed
- k8s/deployment.yaml
- k8s/service.yaml
- k8s/ingress.yaml
- k8s/hpa.yaml
- k8s/network-policy.yaml
- k8s/configmap.yaml
- k8s/secrets.yaml

## Testing
- All Kubernetes manifests now use VERSION_PLACEHOLDER
- No hardcoded versions remain in project templates
- Ready for auto-increment system integration