### PR TITLE
fix: increase deployment wait timeout to match health check settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -431,7 +431,7 @@ jobs:
         echo "✅ Verifying deployment on MicroK8s..."
 
         # Wait for deployments to be ready
-        kubectl wait --for=condition=available --timeout=300s deployment -l app=petrosa-ta-bot -n petrosa-apps --insecure-skip-tls-verify 2>/dev/null || echo "No deployments to wait for"
+        kubectl wait --for=condition=available --timeout=600s deployment -l app=petrosa-ta-bot -n petrosa-apps --insecure-skip-tls-verify 2>/dev/null || echo "No deployments to wait for"
 
         # Show deployment status
         echo "📊 Deployment status:"


### PR DESCRIPTION
## Summary
Preventative fix to increase GitHub Actions deployment timeout.

## Problem
The deployment uses `kubectl wait --timeout=300s` but K8s health checks allow up to 480s:
- startupProbe initialDelaySeconds: 30s  
- startupProbe failureThreshold: 45
- startupProbe periodSeconds: 10s
- **Total max time**: 30s + (45 × 10s) = 480s

## Solution
Increase timeout from 300s to 600s (10 minutes) to align with pod startup requirements.

## Changes
- **.github/workflows/release.yml**: Update timeout from 300s to 600s

## Testing
- ✅ No code changes, only workflow configuration
- ✅ Aligns with health check timeout settings

## Impact
- Prevents false deployment failures
- Allows time for NATS/MySQL connection initialization