### PR TITLE
fix: Copy otel_init.py and scripts to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN pip install opentelemetry-distro opentelemetry-exporter-otlp-proto-grpc \
 # Copy application code
 COPY ta_bot/ ./ta_bot/
 COPY tests/ ./tests/
+COPY scripts/ ./scripts/
+COPY otel_init.py ./
 
 # Force rebuild timestamp
 RUN echo "Build timestamp: $(date)" > /app/build_timestamp.txt


### PR DESCRIPTION
## Problem
- Pod was crashing with `ModuleNotFoundError: No module named 'otel_init'`
- Migration jobs failing with script not found errors

## Solution
- Added `COPY otel_init.py ./` to Dockerfile
- Added `COPY scripts/ ./scripts/` to Dockerfile

## Impact
- Fixes CrashLoopBackOff in K8s deployment
- Enables OpenTelemetry auto-instrumentation
- Fixes MySQL migration jobs

## Testing
- Docker build verified
- Required for OpenTelemetry implementation

Related to OpenTelemetry auto-instrumentation rollout.