### PR TITLE
feat: Add OpenTelemetry traces instrumentation

### DIFF
--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -43,3 +43,13 @@ spec:
     - port: 8000
       protocol: TCP
     to: []
+  # OpenTelemetry (Grafana Alloy)
+  - ports:
+    - port: 4317
+      protocol: TCP
+    - port: 4318
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: observability

--- a/ta_bot/health.py
+++ b/ta_bot/health.py
@@ -45,6 +45,14 @@ SERVICE_UPTIME = Gauge("service_uptime_seconds", "Service uptime in seconds")
 start_time = time.time()
 app = FastAPI(title="TA Bot Health API", version="1.0.0")
 
+# Instrument FastAPI for OpenTelemetry traces
+try:
+    from otel_init import instrument_app
+
+    instrument_app(app)
+except Exception as e:
+    logger.warning(f"Could not instrument FastAPI for traces: {e}")
+
 
 def get_uptime() -> str:
     """Get formatted uptime."""


### PR DESCRIPTION
## Changes
- Add FastAPI instrumentation for health endpoints
- Update network policy for Grafana Alloy access
- Enable distributed tracing for ta-bot service

## Related
Part of Grafana Cloud observability migration