### PR TITLE
fix: prevent OTEL double-initialization and enable observability

### DIFF
--- a/otel_init.py
+++ b/otel_init.py
@@ -42,6 +42,10 @@ def setup_telemetry(
         enable_traces: Whether to enable traces
         enable_logs: Whether to enable logs
     """
+    # Early return if OTEL disabled
+    if os.getenv("ENABLE_OTEL", "true").lower() not in ("true", "1", "yes"):
+        return
+
     # Get configuration from environment variables
     service_version = service_version or os.getenv("OTEL_SERVICE_VERSION", "1.0.0")
     otlp_endpoint = otlp_endpoint or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
@@ -86,11 +90,17 @@ def setup_telemetry(
             tracer_provider = TracerProvider(resource=resource)
 
             # Create OTLP exporter
+            headers_env = os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
+            span_headers: dict[str, str] | None = None
+            if headers_env:
+                # Parse headers as "key1=value1,key2=value2" format
+                headers_list = [
+                    tuple(h.split("=", 1)) for h in headers_env.split(",") if "=" in h
+                ]
+                span_headers = dict(headers_list)
             otlp_exporter = OTLPSpanExporter(
                 endpoint=otlp_endpoint,
-                headers=os.getenv("OTEL_EXPORTER_OTLP_HEADERS", "").split(",")
-                if os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
-                else None,
+                headers=span_headers,
             )
 
             # Add batch processor
@@ -108,12 +118,20 @@ def setup_telemetry(
     if enable_metrics and otlp_endpoint:
         try:
             # Create metric reader
+            metric_headers_env = os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
+            metric_headers: dict[str, str] | None = None
+            if metric_headers_env:
+                # Parse headers as "key1=value1,key2=value2" format
+                metric_headers_list = [
+                    tuple(h.split("=", 1))
+                    for h in metric_headers_env.split(",")
+                    if "=" in h
+                ]
+                metric_headers = dict(metric_headers_list)
             metric_reader = PeriodicExportingMetricReader(
                 OTLPMetricExporter(
                     endpoint=otlp_endpoint,
-                    headers=os.getenv("OTEL_EXPORTER_OTLP_HEADERS", "").split(",")
-                    if os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
-                    else None,
+                    headers=metric_headers,
                 ),
                 export_interval_millis=int(
                     os.getenv("OTEL_METRIC_EXPORT_INTERVAL", "60000")
@@ -204,6 +222,8 @@ def get_meter(name: str = None) -> metrics.Meter:
     return metrics.get_meter(name or "ta-bot")
 
 
-# Auto-setup if environment variable is set
-if os.getenv("OTEL_AUTO_SETUP", "true").lower() in ("true", "1", "yes"):
-    setup_telemetry()
+# Auto-setup if environment variable is set and not disabled
+if os.getenv("ENABLE_OTEL", "true").lower() in ("true", "1", "yes"):
+    if not os.getenv("OTEL_NO_AUTO_INIT"):
+        if os.getenv("OTEL_AUTO_SETUP", "true").lower() in ("true", "1", "yes"):
+            setup_telemetry()


### PR DESCRIPTION
## Summary
Fixes missing traces in Grafana Cloud for ta-bot service by resolving double-initialization bug.

## Changes
- Added ENABLE_OTEL early-return guard to prevent init when disabled
- Fixed OTLP header parsing to use proper key=value format  
- Added OTEL_NO_AUTO_INIT support to prevent double-initialization
- Standardized initialization pattern across all services

## Root Cause
Double-initialization bug caused by mismatched environment variables:
- otel_init.py checked OTEL_AUTO_SETUP for auto-init
- Deployments set OTEL_NO_AUTO_INIT to prevent it
- Different variable names = double initialization

## Testing
✅ All tests passing
✅ Linting passed
✅ OTEL initialization validated
✅ Header parsing verified

## Deployment
Ready for immediate merge and deployment via CI/CD.