### PR TITLE
chore: trigger redeployment to pick up fixed shared configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,3 +413,4 @@ For support and questions:
 **Status**: ✅ Production Ready with 28 Strategies (11 Original + 17 Quantzed-Adapted)
 **Last Updated**: January 2025
 **Version**: 4.0.0 - Advanced Quantzed Integration
+# Trigger redeployment


### PR DESCRIPTION
## Purpose
Forces ta-bot to redeploy so pods restart and pick up the corrected shared configmap.

## Context
The shared `petrosa-common-config` was corrupted when other services deployed
their own conflicting versions. That issue is now fixed, but ta-bot pods need
to restart to pick up the corrected configuration.

## Impact
✅ ta-bot pods restart
✅ Pick up correct OTEL endpoint from shared configmap
✅ Traces will appear in Grafana Cloud

## Deployment
Merge immediately to restore ta-bot observability.