### PR TITLE
fix: Add OTLP log export to bot-ta-analysis

### DIFF
--- a/ta_bot/main.py
+++ b/ta_bot/main.py
@@ -25,6 +25,9 @@ logger = logging.getLogger(__name__)
 async def main():
     """Main entry point for the TA bot."""
     try:
+        # Attach OTLP logging handler for log export
+        otel_init.attach_logging_handler_simple()
+
         # Initialize components
         config = Config()
         signal_engine = SignalEngine()


### PR DESCRIPTION
## Summary

Apply lessons learned from tradeengine logging fix (PR #75) to enable complete observability for the bot-ta-analysis service.

## Changes

### Updated `otel_init.py`
- Added OTLP log export imports and configuration
- Added `attach_logging_handler_simple()` function for root logger attachment
- Configured log export with BatchLogRecordProcessor

### Updated `ta_bot/main.py`
- Call `otel_init.attach_logging_handler_simple()` in main() after OTEL setup
- Explicit handler attachment for async service

## Architecture-Specific Implementation

The bot-ta-analysis service is an **async NATS listener** (no web server), so:
- ✅ Attach to **root logger only** (no uvicorn loggers needed)
- ✅ Handler attached **explicitly** in main() after logging.basicConfig()
- ✅ No lifespan complexity - simple async service

This is different from tradeengine which needs uvicorn logger attachment.

## Expected Outcome

After deployment:
- ✅ TA bot signal processing logs will appear in Grafana Cloud Loki
- ✅ NATS message handling logs exported
- ✅ Strategy execution logs captured
- ✅ Traces and metrics continue working
- ✅ Complete observability achieved

## Verification

Check Grafana Loki for logs:
```logql
{service_name="ta-bot"} |= ""
```

Refs: Part of observability rollout (Service 3/4)