### PR TITLE
feat: fix ta-bot OpenTelemetry trace export

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,12 +23,19 @@ spec:
     spec:
       containers:
       - name: ta-bot
-        image: yurisa2/petrosa-ta-bot:VERSION_PLACEHOLDER
+        image: yurisa2/petrosa-ta-bot:v1.0.66
         imagePullPolicy: Always
+        command:
+          - opentelemetry-instrument
+          - python
+          - '-m'
+          - ta_bot.main
         ports:
         - containerPort: 8000
           name: http
         env:
+        - name: OTEL_NO_AUTO_INIT
+          value: "1"
         - name: NATS_URL
           valueFrom:
             configMapKeyRef:
@@ -82,6 +89,26 @@ spec:
             configMapKeyRef:
               name: petrosa-common-config
               key: OTEL_LOGS_EXPORTER
+        - name: OTEL_EXPORTER_OTLP_HEADERS
+          valueFrom:
+            secretKeyRef:
+              name: petrosa-sensitive-credentials
+              key: OTEL_EXPORTER_OTLP_HEADERS
+        - name: ENABLE_LOGS
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: ENABLE_LOGS
+        - name: ENABLE_METRICS
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: ENABLE_METRICS
+        - name: ENABLE_TRACES
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: ENABLE_TRACES
         - name: SUPPORTED_SYMBOLS
           valueFrom:
             configMapKeyRef:

--- a/ta_bot/health.py
+++ b/ta_bot/health.py
@@ -47,9 +47,9 @@ app = FastAPI(title="TA Bot Health API", version="1.0.0")
 
 # Instrument FastAPI for OpenTelemetry traces
 try:
-    from otel_init import instrument_app
+    from otel_init import instrument_fastapi_app
 
-    instrument_app(app)
+    instrument_fastapi_app(app)
 except Exception as e:
     logger.warning(f"Could not instrument FastAPI for traces: {e}")
 


### PR DESCRIPTION
## 🎯 **Objective**
Fix missing ta-bot service in Grafana traces dashboard by properly configuring OpenTelemetry instrumentation.

## 🔧 **Changes Made**

### OpenTelemetry Configuration Fixes
- ✅ **Added missing environment variables**:
  -  - Required for Grafana Cloud authentication
  - , ,  - Control what gets exported
  -  - Prevents auto-initialization conflicts

### FastAPI Instrumentation Fix
- ✅ **Fixed import error**:  → 
- ✅ **Added opentelemetry-instrument command** to deployment for automatic instrumentation

### Image Architecture Fix
- ✅ **Updated to v1.0.66** with AMD64 architecture support
- ✅ **Fixed exec format error** that was preventing pod startup

## 🎯 **Expected Results**
- ta-bot service should now appear in Grafana traces dashboard
- All 5 services (binance-extractor, tradeengine, realtime-strategies, socket-client, ta-bot) should be visible in traces
- Proper OpenTelemetry instrumentation for HTTP requests, database calls, and other operations

## 🧪 **Testing**
- ✅ Pod starts successfully with new configuration
- ✅ OpenTelemetry instrumentation is active
- ✅ FastAPI application is properly instrumented

## 📊 **Impact**
- **Observability**: Complete trace coverage across all services
- **Debugging**: Better visibility into ta-bot operations
- **Monitoring**: Full service mesh observability in Grafana

## 🔗 **Related Issues**
Resolves missing ta-bot service in Grafana traces dashboard.