### PR TITLE
hotfix: fix ta-bot logging export after OpenTelemetry changes

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: ta-bot
-        image: yurisa2/petrosa-ta-bot:v1.0.66
+        image: yurisa2/petrosa-ta-bot:v1.0.67
         imagePullPolicy: Always
         command:
           - opentelemetry-instrument

--- a/ta_bot/main.py
+++ b/ta_bot/main.py
@@ -25,7 +25,8 @@ logger = logging.getLogger(__name__)
 async def main():
     """Main entry point for the TA bot."""
     try:
-        # Attach OTLP logging handler for log export
+        # Set up OpenTelemetry and attach OTLP logging handler for log export
+        otel_init.setup_telemetry()
         otel_init.attach_logging_handler_simple()
 
         # Initialize components


### PR DESCRIPTION
Emergency fix for ta-bot logging export that was broken after OpenTelemetry instrumentation changes. Added missing setup_telemetry() call in main.py before attach_logging_handler_simple(). Updated image to v1.0.67. Resolves issue where ta-bot logs stopped after initialization.