### PR TITLE
fix: invalid timestamp generation causing NATS message processing failures

### DIFF
--- a/ta_bot/strategies/bear_trap_buy.py
+++ b/ta_bot/strategies/bear_trap_buy.py
@@ -14,6 +14,7 @@ as the price quickly reverses upward.
 """
 
 import logging
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 import pandas as pd
@@ -107,7 +108,7 @@ class BearTrapBuyStrategy(BaseStrategy):
                     strength=SignalStrength.MEDIUM,
                     stop_loss=stop_loss,
                     take_profit=take_profit,
-                    timestamp=str(data.index[-1]),
+                    timestamp=datetime.utcnow().isoformat(),
                     metadata={
                         "ema80": current_ema80,
                         "trap_depth": abs(current_low - current_ema80),

--- a/ta_bot/strategies/bear_trap_sell.py
+++ b/ta_bot/strategies/bear_trap_sell.py
@@ -13,6 +13,7 @@ This is the opposite of the Bear Trap Buy - here bulls get trapped
 in long positions as the price fails to sustain above key resistance.
 """
 
+from datetime import datetime
 from typing import Optional
 
 import pandas as pd
@@ -114,7 +115,7 @@ class BearTrapSellStrategy(BaseStrategy):
                     entry_price=entry_price,
                     stop_loss=stop_loss,
                     take_profit=take_profit,
-                    timestamp=data.index[-1],
+                    timestamp=datetime.utcnow().isoformat(),
                     metadata={
                         "ema80": current_ema80,
                         "false_breakout_height": false_breakout_height,

--- a/ta_bot/strategies/doji_reversal.py
+++ b/ta_bot/strategies/doji_reversal.py
@@ -14,6 +14,7 @@ a reversal could be imminent.
 """
 
 import logging
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 import pandas as pd
@@ -122,7 +123,7 @@ class DojiReversalStrategy(BaseStrategy):
                     strength=SignalStrength.LOW,  # Doji is more of a warning than strong signal
                     stop_loss=stop_loss,
                     take_profit=take_profit,
-                    timestamp=str(data.index[-1]),
+                    timestamp=datetime.utcnow().isoformat(),
                     metadata={
                         "body_size": body_size,
                         "total_range": price_range,

--- a/ta_bot/strategies/ema_alignment_bearish.py
+++ b/ta_bot/strategies/ema_alignment_bearish.py
@@ -12,6 +12,7 @@ This is the bearish counterpart to the EMA Alignment Bullish strategy,
 confirming strong downtrend conditions with multiple EMA confirmations.
 """
 
+from datetime import datetime
 from typing import Optional
 
 import pandas as pd
@@ -125,7 +126,7 @@ class EMAAlignmentBearishStrategy(BaseStrategy):
                     entry_price=entry_price,
                     stop_loss=stop_loss,
                     take_profit=take_profit,
-                    timestamp=data.index[-1],
+                    timestamp=datetime.utcnow().isoformat(),
                     metadata={
                         "ema8": current_ema8,
                         "ema80": current_ema80,

--- a/ta_bot/strategies/ema_slope_reversal_sell.py
+++ b/ta_bot/strategies/ema_slope_reversal_sell.py
@@ -13,6 +13,7 @@ and bearish momentum begins to take control.
 """
 
 import logging
+from datetime import datetime
 from typing import Optional
 
 import pandas as pd
@@ -114,7 +115,7 @@ class EMASlopeReversalSellStrategy(BaseStrategy):
                     strength=SignalStrength.MEDIUM,
                     stop_loss=stop_loss,
                     take_profit=take_profit,
-                    timestamp=str(data.index[-1]),
+                    timestamp=datetime.utcnow().isoformat(),
                     metadata={
                         "ema9": current_ema9,
                         "current_inclination": current_inclination,

--- a/ta_bot/strategies/inside_bar_sell.py
+++ b/ta_bot/strategies/inside_bar_sell.py
@@ -13,6 +13,7 @@ in a bearish context, they often precede further downward movement.
 """
 
 import logging
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 import pandas as pd
@@ -110,7 +111,7 @@ class InsideBarSellStrategy(BaseStrategy):
                     strength=SignalStrength.MEDIUM,
                     stop_loss=stop_loss,
                     take_profit=take_profit,
-                    timestamp=str(data.index[-1]),
+                    timestamp=datetime.utcnow().isoformat(),
                     metadata={
                         "ema8": current_ema8,
                         "ema80": current_ema80,

--- a/ta_bot/strategies/minervini_trend_template.py
+++ b/ta_bot/strategies/minervini_trend_template.py
@@ -18,6 +18,7 @@ This is a comprehensive trend-following strategy that identifies assets
 with institutional-quality momentum characteristics.
 """
 
+from datetime import datetime
 from typing import Optional
 
 import pandas as pd
@@ -176,7 +177,7 @@ class MinerviniTrendTemplateStrategy(BaseStrategy):
                     entry_price=entry_price,
                     stop_loss=stop_loss,
                     take_profit=take_profit,
-                    timestamp=data.index[-1],
+                    timestamp=datetime.utcnow().isoformat(),
                     metadata={
                         "sma50": current_sma50,
                         "sma150": current_sma150,

--- a/ta_bot/strategies/shooting_star_reversal.py
+++ b/ta_bot/strategies/shooting_star_reversal.py
@@ -14,6 +14,7 @@ showing that buyers pushed price higher but sellers ultimately took control.
 """
 
 import logging
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 import pandas as pd
@@ -107,7 +108,7 @@ class ShootingStarReversalStrategy(BaseStrategy):
                     strength=SignalStrength.MEDIUM,
                     stop_loss=stop_loss,
                     take_profit=take_profit,
-                    timestamp=str(data.index[-1]),
+                    timestamp=datetime.utcnow().isoformat(),
                     metadata={
                         "body_size": body_size,
                         "upper_shadow": upper_shadow,


### PR DESCRIPTION
## Overview
Fixes invalid timestamp generation in strategy files that was causing signal processing failures in the tradeengine.

## Problem
Strategies were using `timestamp=str(data.index[-1])` or `timestamp=data.index[-1]` which converted pandas numeric indices to invalid strings like "99" instead of proper ISO datetime format.

This caused the error:
```
❌ INVALID TIMESTAMP FORMAT | Timestamp: 99 | Error: Invalid isoformat string: '99'
```

## Solution
- Changed all strategies to use `datetime.utcnow().isoformat()`
- Added `from datetime import datetime` import to all affected files
- Generates proper ISO format timestamps for NATS messages

## Affected Strategy Files (8 total)
✅ shooting_star_reversal.py
✅ inside_bar_sell.py
✅ ema_slope_reversal_sell.py
✅ doji_reversal.py
✅ bear_trap_buy.py
✅ minervini_trend_template.py
✅ ema_alignment_bearish.py
✅ bear_trap_sell.py

## Testing
- ✅ All linter checks passed
- ✅ Pre-commit hooks passed
- Ready for deployment

## Impact
- Signals will now have valid timestamps
- Tradeengine will process all signals without timestamp errors
- Works in conjunction with tradeengine PR #120 for graceful fallback