### PR TITLE
fix: increase probe timeouts from 5s to 10s

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -206,7 +206,7 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           periodSeconds: 10
-          timeoutSeconds: 5
+          timeoutSeconds: 10
           failureThreshold: 3
         readinessProbe:
           httpGet:
@@ -214,7 +214,7 @@ spec:
             port: 8000
           initialDelaySeconds: 10
           periodSeconds: 5
-          timeoutSeconds: 5
+          timeoutSeconds: 10
           failureThreshold: 5
         startupProbe:
           httpGet:
@@ -222,7 +222,7 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           periodSeconds: 10
-          timeoutSeconds: 5
+          timeoutSeconds: 10
           failureThreshold: 45
       restartPolicy: Always
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Summary

Fixes #89 - TA Bot readiness probe timeout causing intermittent failures

Increased probe timeout values from 5 seconds to 10 seconds to handle occasional slow health endpoint responses.

## Changes

- ✅ Increased `livenessProbe.timeoutSeconds` from 5 to 10
- ✅ Increased `readinessProbe.timeoutSeconds` from 5 to 10  
- ✅ Increased `startupProbe.timeoutSeconds` from 5 to 10

## Problem Addressed

The TA Bot deployment was experiencing 119 probe timeout failures over a 5-hour period. The `/ready` endpoint occasionally took longer than 5 seconds to respond, causing false negatives in readiness checks even though the service was functioning normally.

## Testing

- ✅ YAML syntax validated by pre-commit hooks
- ✅ No code changes - configuration only
- CI/CD will validate:
  - Manifest validation
  - Kubernetes schema validation
  - Dry-run deployment check

## Success Criteria

After deployment:
- Zero probe timeout failures over 24-hour observation period
- Health endpoint responses complete within new 10s timeout
- No impact on service availability or traffic routing

## References

- Issue: #89
- Similar fix in realtime-strategies: PR #34
- Kubernetes probe best practices: [docs.k8s.io](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)