### PR TITLE
[BUG] Enforce VERSION_PLACEHOLDER Standard and Restore Local Manifests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,23 @@ jobs:
         kubectl cluster-info --insecure-skip-tls-verify
         kubectl get nodes --insecure-skip-tls-verify
 
+    - name: Verify no hardcoded image tags in manifests
+      if: steps.check-k8s.outputs.skip-deploy == 'false'
+      run: |
+        echo "🔍 Verifying that no hardcoded semantic version tags exist in k8s/ manifests..."
+        # Search for pattern image: yurisa2/petrosa.*:v*
+        # VERSION_PLACEHOLDER is allowed
+        HARDCODED_TAGS=$(grep -rE "image: yurisa2/petrosa.*:v[0-9]+" k8s/ || true)
+
+        if [ -n "$HARDCODED_TAGS" ]; then
+          echo "❌ ERROR: Found hardcoded image tags in manifests:"
+          echo "$HARDCODED_TAGS"
+          echo "💡 Manifests must use VERSION_PLACEHOLDER for CI/CD injection."
+          exit 1
+        else
+          echo "✅ No hardcoded tags found."
+        fi
+
     - name: Update image tags in manifests
       if: steps.check-k8s.outputs.skip-deploy == 'false'
       run: |

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ta-bot-config
+  namespace: petrosa-apps
+  labels:
+    app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
+data:
+  # Signal Publishing Configuration
+  # ENABLE_REST_PUBLISHING: Set to "false" to prevent duplicate signals (NATS-only mode)
+  # Set to "true" only if you need REST API publishing for backward compatibility
+  enable_rest_publishing: "false"
+  api_endpoint: "http://petrosa-tradeengine-service/trade/signal"
+  rsi_period: "14"
+  macd_fast: "12"
+  macd_slow: "26"
+  macd_signal: "9"
+  adx_period: "14"
+  bb_period: "20"
+  bb_std: "2.0"
+  atr_period: "14"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,228 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: petrosa-ta-bot
+  namespace: petrosa-apps
+  labels:
+    app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: petrosa-ta-bot
+  template:
+    metadata:
+      labels:
+        app: petrosa-ta-bot
+        version: VERSION_PLACEHOLDER
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+      - name: ta-bot
+        image: yurisa2/petrosa-ta-bot:VERSION_PLACEHOLDER
+        imagePullPolicy: Always
+        command:
+          - opentelemetry-instrument
+          - python
+          - '-m'
+          - ta_bot.main
+        ports:
+        - containerPort: 8000
+          name: http
+        env:
+        - name: OTEL_NO_AUTO_INIT
+          value: "1"
+        - name: NATS_URL
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: NATS_URL
+        - name: API_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: ta-bot-config
+              key: api_endpoint
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: LOG_LEVEL
+        - name: ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: ENVIRONMENT
+        # OpenTelemetry Configuration
+        - name: ENABLE_OTEL
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: ENABLE_OTEL
+        - name: OTEL_SERVICE_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_SERVICE_VERSION
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_EXPORTER_OTLP_ENDPOINT
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=ta-bot,service.version=VERSION_PLACEHOLDER
+        - name: OTEL_METRICS_EXPORTER
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_METRICS_EXPORTER
+        - name: OTEL_TRACES_EXPORTER
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_TRACES_EXPORTER
+        - name: OTEL_LOGS_EXPORTER
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_LOGS_EXPORTER
+        - name: OTEL_EXPORTER_OTLP_HEADERS
+          valueFrom:
+            secretKeyRef:
+              name: petrosa-sensitive-credentials
+              key: OTEL_EXPORTER_OTLP_HEADERS
+        - name: ENABLE_LOGS
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: ENABLE_LOGS
+        - name: ENABLE_METRICS
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: ENABLE_METRICS
+        - name: ENABLE_TRACES
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: ENABLE_TRACES
+        - name: SUPPORTED_SYMBOLS
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: DEFAULT_SYMBOLS
+        - name: SUPPORTED_TIMEFRAMES
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: SUPPORTED_INTERVALS
+        - name: RSI_PERIOD
+          valueFrom:
+            configMapKeyRef:
+              name: ta-bot-config
+              key: rsi_period
+        - name: MACD_FAST
+          valueFrom:
+            configMapKeyRef:
+              name: ta-bot-config
+              key: macd_fast
+        - name: MACD_SLOW
+          valueFrom:
+            configMapKeyRef:
+              name: ta-bot-config
+              key: macd_slow
+        - name: MACD_SIGNAL
+          valueFrom:
+            configMapKeyRef:
+              name: ta-bot-config
+              key: macd_signal
+        - name: ADX_PERIOD
+          valueFrom:
+            configMapKeyRef:
+              name: ta-bot-config
+              key: adx_period
+        - name: BB_PERIOD
+          valueFrom:
+            configMapKeyRef:
+              name: ta-bot-config
+              key: bb_period
+        - name: BB_STD
+          valueFrom:
+            configMapKeyRef:
+              name: ta-bot-config
+              key: bb_std
+        - name: ATR_PERIOD
+          valueFrom:
+            configMapKeyRef:
+              name: ta-bot-config
+              key: atr_period
+        - name: NATS_ENABLED
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: NATS_ENABLED
+        - name: NATS_SUBJECT_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: NATS_SUBJECT_PREFIX
+        - name: NATS_SUBJECT_PREFIX_PRODUCTION
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: NATS_SUBJECT_PREFIX_PRODUCTION
+        - name: MYSQL_HOST
+          value: "mysql-server"
+        - name: MYSQL_PORT
+          value: "3306"
+        - name: MYSQL_USER
+          value: "petrosa"
+        - name: MYSQL_URI
+          valueFrom:
+            secretKeyRef:
+              name: petrosa-sensitive-credentials
+              key: MYSQL_URI
+        - name: MYSQL_DATABASE
+          value: "petrosa"
+        # Data Manager API configuration
+        - name: DATA_MANAGER_URL
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: DATA_MANAGER_URL
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 10
+          failureThreshold: 5
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 45
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,44 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: petrosa-ta-bot-hpa
+  namespace: petrosa-apps
+  labels:
+    app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: petrosa-ta-bot
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 10
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 15
+      - type: Pods
+        value: 2
+        periodSeconds: 15

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: petrosa-ta-bot-ingress
+  namespace: petrosa-apps
+  labels:
+    app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  tls:
+  - hosts:
+    - ta-bot.petrosa.com
+    secretName: ta-bot-tls # pragma: allowlist secret
+  rules:
+  - host: ta-bot.petrosa.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: petrosa-ta-bot-service
+            port:
+              number: 80

--- a/k8s/mysql-migration-job.yaml
+++ b/k8s/mysql-migration-job.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ta-bot-mysql-migration-timeframe
+  namespace: petrosa-apps
+  labels:
+    app: petrosa-ta-bot
+    component: database-migration
+    migration: add-timeframe-column
+spec:
+  ttlSecondsAfterFinished: 3600  # Clean up after 1 hour
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: petrosa-ta-bot
+        component: database-migration
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: mysql-migration
+        image: yurisa2/petrosa-ta-bot:v1.0.51
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            echo "Starting MySQL migration - Add timeframe column"
+
+            # Parse MYSQL_URI to get connection details
+            # Actual format: mysql+pymysql://user:pass@host:port/database
+            MYSQL_HOST=$(echo $MYSQL_URI | sed -n 's|.*@\([^:]*\):.*|\1|p')
+            MYSQL_PORT=$(echo $MYSQL_URI | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
+            MYSQL_USER=$(echo $MYSQL_URI | sed -n 's|mysql[^:]*://\([^:]*\):.*|\1|p')
+            MYSQL_PASSWORD=$(echo $MYSQL_URI | sed -n 's|mysql[^:]*://[^:]*:\([^@]*\)@.*|\1|p')
+            MYSQL_DATABASE=$(echo $MYSQL_URI | sed -n 's|.*/\([^?]*\).*|\1|p')
+
+            export MYSQL_HOST MYSQL_PORT MYSQL_USER MYSQL_PASSWORD MYSQL_DATABASE
+
+            echo "Database: $MYSQL_DATABASE"
+            echo "Host: $MYSQL_HOST:$MYSQL_PORT"
+            echo "User: $MYSQL_USER"
+
+            # Run the migration script
+            python3 /app/scripts/run_mysql_migration.py
+
+            echo "Migration completed successfully!"
+        env:
+          - name: MYSQL_URI
+            valueFrom:
+              secretKeyRef:
+                name: petrosa-sensitive-credentials
+                key: MYSQL_URI
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi

--- a/k8s/network-policy-ingress.yaml
+++ b/k8s/network-policy-ingress.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: petrosa-ta-bot-allow-ingress
+  namespace: petrosa-apps
+  labels:
+    app: petrosa-ta-bot
+spec:
+  podSelector:
+    matchLabels:
+      app: petrosa-ta-bot
+  policyTypes:
+  - Ingress
+
+  ingress:
+  # Allow traffic from within the namespace
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: petrosa-apps
+    ports:
+    - protocol: TCP
+      port: 8000
+
+  # Allow monitoring from observability namespace
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: observability
+    ports:
+    - protocol: TCP
+      port: 8000

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -1,0 +1,55 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: petrosa-ta-bot-allow-egress
+  namespace: petrosa-apps
+  labels:
+    app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
+spec:
+  podSelector:
+    matchLabels:
+      app: petrosa-ta-bot
+  policyTypes:
+  - Egress
+  egress:
+  # DNS
+  - ports:
+    - port: 53
+      protocol: UDP
+    to: []
+  # HTTP/HTTPS
+  - ports:
+    - port: 80
+      protocol: TCP
+    - port: 443
+      protocol: TCP
+    to: []
+  # NATS
+  - ports:
+    - port: 4222
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          name: nats
+  # MySQL (for external database)
+  - ports:
+    - port: 3306
+      protocol: TCP
+    to: []
+  # HTTP for health checks
+  - ports:
+    - port: 8000
+      protocol: TCP
+    to: []
+  # OpenTelemetry (Grafana Alloy)
+  - ports:
+    - port: 4317
+      protocol: TCP
+    - port: 4318
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: observability

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ta-bot-secrets
+  namespace: petrosa-apps
+  labels:
+    app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
+type: Opaque
+data:
+  # Base64 encoded secrets - replace with actual values
+  # echo -n "your-secret-value" | base64
+  nats_username: ""
+  nats_password: ""
+  api_auth_token: ""

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: petrosa-ta-bot-service
+  namespace: petrosa-apps
+  labels:
+    app: petrosa-ta-bot
+    version: VERSION_PLACEHOLDER
+spec:
+  selector:
+    app: petrosa-ta-bot
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8000
+    protocol: TCP
+  type: ClusterIP


### PR DESCRIPTION
Resolves #144. \n\n- Restores 'k8s/' manifests to the local repository from 'petrosa_k8s' hub.\n- Enforces 'VERSION_PLACEHOLDER' in deployment.yaml.\n- Adds CI verification step in release.yml to prevent hardcoded semantic version tags in manifests.