### PR TITLE
[BUG] Standardize Strategy Risk Metadata

### DIFF
--- a/ta_bot/core/signal_engine.py
+++ b/ta_bot/core/signal_engine.py
@@ -396,8 +396,15 @@ class SignalEngine:
                         f"  {strategy_name}: Using strategy-defined TP/SL - SL: {signal.stop_loss:.2f}, TP: {signal.take_profit:.2f}"
                     )
 
+                # Hard Validation for risk parameters
+                if not self.validate_risk_parameters(signal):
+                    logger.error(
+                        f"  {strategy_name}: REJECTED - Missing or invalid risk parameters for {signal.action}"
+                    )
+                    return None
+
                 # Validate signal
-                if not signal.validate():
+                if not signal.validate(strict_risk=True):
                     logger.warning(
                         f"  {strategy_name}: Invalid signal generated - validation failed"
                     )
@@ -422,6 +429,36 @@ class SignalEngine:
                     },
                 )
                 return None
+
+    def validate_risk_parameters(self, signal: Signal) -> bool:
+        """
+        Validate that buy/sell signals have required risk parameters.
+
+        Args:
+            signal: The generated signal to validate.
+
+        Returns:
+            True if validation passes, False otherwise.
+        """
+        if signal.action not in ["buy", "sell"]:
+            return True
+
+        if signal.stop_loss is None or signal.take_profit is None:
+            logger.error(
+                f"Validation failed for {signal.strategy_id}: action={signal.action} "
+                f"requires stop_loss and take_profit"
+            )
+            return False
+
+        # Ensure values are positive
+        if signal.stop_loss <= 0 or signal.take_profit <= 0:
+            logger.error(
+                f"Validation failed for {signal.strategy_id}: risk parameters must be positive. "
+                f"SL: {signal.stop_loss}, TP: {signal.take_profit}"
+            )
+            return False
+
+        return True
 
     def _calculate_signal_strength(self, confidence: float) -> SignalStrength:
         """Calculate signal strength based on confidence."""

--- a/ta_bot/models/signal.py
+++ b/ta_bot/models/signal.py
@@ -70,6 +70,12 @@ def sanitize_json_value(value: Any) -> Any:
     return value
 
 
+class ValidationError(Exception):
+    """Raised when a signal fails validation."""
+
+    pass
+
+
 @dataclass
 class Signal:
     """Trading signal data model - aligned with Trade Engine format."""
@@ -148,8 +154,13 @@ class Signal:
 
         return signal_dict
 
-    def validate(self) -> bool:
-        """Validate signal data."""
+    def validate(self, strict_risk: bool = False) -> bool:
+        """
+        Validate signal data.
+
+        Args:
+            strict_risk: If True, requires stop_loss and take_profit for buy/sell actions.
+        """
         if not (0.0 <= self.confidence <= 1.0):
             return False
 
@@ -158,5 +169,15 @@ class Signal:
 
         if self.current_price <= 0 or self.price <= 0:
             return False
+
+        # Hard validation for risk parameters if requested
+        if strict_risk and self.action in ["buy", "sell"]:
+            if self.stop_loss is None or self.take_profit is None:
+                return False
+            # Also ensure they are positive and valid numbers
+            if not (self.stop_loss > 0 and self.take_profit > 0):
+                return False
+            if math.isnan(self.stop_loss) or math.isnan(self.take_profit):
+                return False
 
         return True

--- a/tests/test_risk_validation.py
+++ b/tests/test_risk_validation.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for strategy risk metadata validation.
+"""
+
+import pytest
+
+from ta_bot.core.signal_engine import SignalEngine
+from ta_bot.models.signal import Signal, ValidationError
+
+
+def test_signal_validation_strict_risk():
+    """Test Signal.validate(strict_risk=True) method."""
+    # Valid BUY signal with SL/TP
+    signal = Signal(
+        strategy_id="test",
+        symbol="BTCUSDT",
+        action="buy",
+        confidence=0.8,
+        current_price=50000.0,
+        price=50000.0,
+        stop_loss=49000.0,
+        take_profit=51000.0,
+    )
+    assert signal.validate(strict_risk=True) is True
+
+    # Invalid BUY signal without SL/TP
+    signal = Signal(
+        strategy_id="test",
+        symbol="BTCUSDT",
+        action="buy",
+        confidence=0.8,
+        current_price=50000.0,
+        price=50000.0,
+    )
+    assert signal.validate(strict_risk=True) is False
+
+    # Invalid BUY signal with NaN SL
+    import math
+
+    signal = Signal(
+        strategy_id="test",
+        symbol="BTCUSDT",
+        action="buy",
+        confidence=0.8,
+        current_price=50000.0,
+        price=50000.0,
+        stop_loss=float("nan"),
+        take_profit=51000.0,
+    )
+    assert signal.validate(strict_risk=True) is False
+
+    # HOLD signal doesn't need SL/TP even in strict mode
+    signal = Signal(
+        strategy_id="test",
+        symbol="BTCUSDT",
+        action="hold",
+        confidence=0.8,
+        current_price=50000.0,
+        price=50000.0,
+    )
+    assert signal.validate(strict_risk=True) is True
+
+
+def test_signal_engine_validation():
+    """Test SignalEngine.validate_risk_parameters method."""
+    engine = SignalEngine()
+
+    # Valid BUY signal
+    signal = Signal(
+        strategy_id="test",
+        symbol="BTCUSDT",
+        action="buy",
+        confidence=0.8,
+        current_price=50000.0,
+        price=50000.0,
+        stop_loss=49000.0,
+        take_profit=51000.0,
+    )
+    assert engine.validate_risk_parameters(signal) is True
+
+    # Invalid BUY signal (missing parameters)
+    signal = Signal(
+        strategy_id="test",
+        symbol="BTCUSDT",
+        action="buy",
+        confidence=0.8,
+        current_price=50000.0,
+        price=50000.0,
+    )
+    assert engine.validate_risk_parameters(signal) is False
+
+    # Invalid SELL signal (negative parameters)
+    signal = Signal(
+        strategy_id="test",
+        symbol="BTCUSDT",
+        action="sell",
+        confidence=0.8,
+        current_price=50000.0,
+        price=50000.0,
+        stop_loss=-100.0,
+        take_profit=51000.0,
+    )
+    assert engine.validate_risk_parameters(signal) is False


### PR DESCRIPTION
Fixes #145. \n\n- Enhances 'Signal' model with strict validation option for risk parameters.\n- Implements 'validate_risk_parameters' in 'SignalEngine' to enforce presence of SL/TP for BUY/SELL signals.\n- Adds unit tests to verify the validation logic.