### PR TITLE
fix: 199 - GitOps runs on manual (workflow_dispatch) main deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,10 @@ jobs:
     name: GitOps Update
     needs: [build-and-push, create-release]
     runs-on: petrosa-org-runners
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Run for any main-branch deploy path. Previously only `push` was allowed, so
+    # `workflow_dispatch` built/pushed images but never updated petrosa_k8s — a common
+    # cause of "stale" pods when ops used manual runs (GitOps never received a new tag).
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     steps:
       - name: Generate GitOps Bot Token
         uses: tibdex/github-app-token@v2


### PR DESCRIPTION
## Summary
Closes the gap where `Deploy` ran `create-release` and `build-and-push` on `workflow_dispatch` but **skipped** `gitops-update` because the job was gated to `push` only. The cluster never received a new image tag in `petrosa_k8s`, so pods could stay stale until a push-to-main deploy.

## Changes
- Broaden `gitops-update` `if` to run on `main` for both `push` and `workflow_dispatch`.

## Related
- `petrosa_k8s` PR: imagePullPolicy alignment (see companion PR).

Fixes PetroSa2/petrosa-bot-ta-analysis#199

Made with [Cursor](https://cursor.com)