### PR TITLE
fix: 497 - build-and-push on ubuntu-latest (Docker unavailable on ARC)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: ['main']
   workflow_dispatch:
     inputs:
       version_bump:
@@ -63,7 +63,10 @@ jobs:
   build-and-push:
     name: Build & Push
     needs: create-release
-    runs-on: petrosa-org-runners
+    # Build requires Docker socket / buildx, which stock self-hosted ARC
+    # (runAsNonRoot, no docker.sock) cannot provide. Other jobs stay on
+    # petrosa-org-runners. See petrosa_k8s#497.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -133,7 +136,6 @@ jobs:
       - name: Rebase on main
         run: ./scripts/gitops-rebase-main.sh
         working-directory: petrosa_k8s
-
 
 
       - name: Update ta-bot image tag in GitOps manifests

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,17 @@
+extends: default
+
+rules:
+  # GitHub Actions YAML uses sequences at the same indentation level as their
+  # mapping key (steps: / - name:) — this is idiomatic but non-default for yamllint.
+  indentation:
+    indent-sequences: whatever
+  # Allow longer lines in CI workflow files (build-args, run scripts, etc.)
+  line-length:
+    max: 320
+  # GitHub Actions uses 'on:' as a key — allow the bare boolean synonym
+  truthy:
+    allowed-values: ['true', 'false']
+    check-keys: false
+  # Allow multiple blank lines between jobs/steps for readability
+  empty-lines:
+    max: 2


### PR DESCRIPTION
## Summary

- Restores `runs-on: ubuntu-latest` for the `build-and-push` job in `.github/workflows/deploy.yml`. The other three jobs stay on `petrosa-org-runners`.
- Adds the fleet-standard `.yamllint.yml` (matching petrosa-cio) and clears two pre-existing yamllint violations in `deploy.yml` so the lint gate accepts GitHub Actions idioms.

## Why

PR #215 (`853ffa6`, *\"Reverting unauthorized changes to workflow runners\"*) flipped `build-and-push` back to `petrosa-org-runners` without verifying the runner could do Docker. It cannot: stock ARC image, `runAsNonRoot: true`, no `docker.sock`, no DinD/buildkit. As a result `build-and-push` has failed on every push since 2026-05-03 and the live deployment has been pinned at `v1.0.0-r30-8edd26f`.

Sibling services already documented the correct pattern:
- petrosa-cio PR #264 (`7a4bcaa`)
- petrosa-binance-data-extractor PR #200 (`e981f41`)
- petrosa-data-manager PR #84 (`38780e3`)

Policy in one line: **Build = `ubuntu-latest`. Everything else = `petrosa-org-runners`.**

Closes PetroSa2/petrosa_k8s#497

## Test plan

- [ ] CI: deploy.yml run on this PR's branch produces an image and pushes to Docker Hub
- [ ] After merge to main: GitOps job commits the new tag into `petrosa_k8s/k8s/bot-ta-analysis/deployment.yaml`
- [ ] `gh run list --workflow=deploy.yml --branch main --limit 1` shows success (replacing the 14-day failure streak)
- [ ] Optional: manual deploy via `workflow_dispatch` to bring bot-ta-analysis back to current code

🤖 Generated with [Claude Code](https://claude.com/claude-code)