### PR TITLE
fix: #502 - rename Docker image + OTEL service to petrosa-bot-ta-analysis

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,8 +99,8 @@ jobs:
         context: .
         push: true
         tags: |
-          yurisa2/petrosa-ta-bot:${{ steps.version.outputs.version }}
-          yurisa2/petrosa-ta-bot:latest
+          yurisa2/petrosa-bot-ta-analysis:${{ steps.version.outputs.version }}
+          yurisa2/petrosa-bot-ta-analysis:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: |
@@ -142,7 +142,7 @@ jobs:
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           # Update the image tag in manifests robustly
-          find petrosa_k8s/k8s/bot-ta-analysis -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-ta-bot):[^[:space:]]*|\1\2\3:$VERSION|g"
+          find petrosa_k8s/k8s/bot-ta-analysis -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-bot-ta-analysis):[^[:space:]]*|\1\2\3:$VERSION|g"
 
           # Update version labels specifically
           find petrosa_k8s/k8s/bot-ta-analysis -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s/^([[:space:]]*(version|app\.kubernetes\.io\/version)):.*/\1: $VERSION/g"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,14 +31,18 @@ repos:
     hooks:
       - id: bandit
         name: 🔐 Bandit (Python Security)
+        # Scan ONLY first-party source dirs. The previous --exclude pattern
+        # did not match nested venv paths reliably, so bandit was scanning
+        # IPython/etc. inside ./venv and tripping on hundreds of third-party
+        # findings. Whitelist-style targeting via -r ta_bot scripts is
+        # easier to reason about than blacklist-style excludes.
         args:
           - -ll
           - -r
-          - .
+          - ta_bot
+          - scripts
           - -s
           - B608
-          - --exclude
-          - 'tests,venv,.venv,.venv-pipeline,.git,__pycache__,.eggs,*.egg,node_modules'
         pass_filenames: false
 
   # ==================================================================

--- a/ta_bot/main.py
+++ b/ta_bot/main.py
@@ -49,7 +49,7 @@ async def main():
         # 1. Setup OpenTelemetry (before attaching handler)
         if initialize_telemetry_standard and not os.getenv("OTEL_NO_AUTO_INIT"):
             initialize_telemetry_standard(
-                service_name=os.getenv("OTEL_SERVICE_NAME", "petrosa-ta-bot"),
+                service_name=os.getenv("OTEL_SERVICE_NAME", "petrosa-bot-ta-analysis"),
                 service_type="fastapi",
                 enable_fastapi=True,
                 enable_mongodb=True,


### PR DESCRIPTION
## Summary

Closes the **bot-ta-analysis half** of [PetroSa2/petrosa_k8s#502](https://github.com/PetroSa2/petrosa_k8s/issues/502). Companion petrosa_k8s PR updates the corresponding image refs / DEPLOYMENT_NAME map / stale docs. Both PRs must land together for the atomic rename to be coherent.

## What changed

- **`.github/workflows/deploy.yml` lines 102-103, 145** — Docker push target `yurisa2/petrosa-ta-bot` → `yurisa2/petrosa-bot-ta-analysis` (and `:latest`). GitOps sed pattern updated to match new image name.
- **`ta_bot/main.py` line 52** — OTEL `service_name` default `"petrosa-ta-bot"` → `"petrosa-bot-ta-analysis"`. Aligns with k8s Deployment name + the rename mandate from closed #247.
- **`.pre-commit-config.yaml`** — bandit hook now scans only `ta_bot/` and `scripts/` instead of recursing from `.` with a broken exclude pattern. Without this, ALL commits in this repo were failing on hundreds of third-party findings inside `./venv/`. Cleanup pre-existing repo issue.

## Why the bandit config change

The previous `--exclude` pattern (`'tests,venv,.venv,...'`) did not reliably match nested paths during `-r .`. Bandit was scanning `./venv/lib/python3.13/site-packages/IPython/...` and tripping on hundreds of unrelated findings. Whitelisting `ta_bot scripts` is more robust and matches the intent.

## Rollback path

The existing `yurisa2/petrosa-ta-bot` Docker repo retains its 145 tags. Reverting this PR (+ the companion) restores the old image path. No tag deletion.

## Companion PR

`PetroSa2/petrosa_k8s` — updates `k8s/bot-ta-analysis/deployment.yaml`, `mysql-migration-job.yaml`, `DEPLOYMENT_NAME` map in 2 workflow files, `templates/deployment-template.yaml` label, and stale docs under `_memory/prds/llm-strategist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)