### PR TITLE
feat(#580): add intent_id generation and OTel tracing to ta_bot publisher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ opentelemetry-semantic-conventions>=0.41b0
 pandas>=2.0.0
 
 # Petrosa OTel package
-petrosa-otel[all]==1.0.4
+petrosa-otel[all]>=1.0.6
 prometheus-client>=0.17.0
 pydantic>=2.0.0
 pydantic-settings>=2.0.0

--- a/ta_bot/models/signal.py
+++ b/ta_bot/models/signal.py
@@ -4,20 +4,25 @@ Aligned with petrosa-cio contracts.
 """
 
 import math
+import uuid
 from datetime import datetime
 
 try:
     from datetime import UTC
 except ImportError:
     from datetime import timezone
+
     UTC = timezone.utc  # noqa: UP017
 try:
     from enum import StrEnum
 except ImportError:
     from enum import Enum
+
     class StrEnum(str, Enum):
         def __str__(self):
             return str(self.value)
+
+
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -140,6 +145,12 @@ class Signal(BaseModel):
     take_profit: float | None = Field(None, description="Take profit price")
     take_profit_pct: float | None = Field(None, ge=0, le=1)
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    # Traceability: intent_id generated per signal, carried through to CIO
+    intent_id: str = Field(
+        default_factory=lambda: uuid.uuid4().hex,
+        description="uuid4 hex string uniquely identifying this intent; generated at publish time",
+    )
 
     # Add legacy/compatibility fields
     signal_id: str | None = Field(None, description="Compatibility with contracts")

--- a/ta_bot/services/publisher.py
+++ b/ta_bot/services/publisher.py
@@ -167,6 +167,24 @@ class SignalPublisher:
                 # Inject OpenTelemetry trace context for distributed tracing
                 signal_data = NATSTracePropagator.inject_context(signal_data)
 
+                # Set decision.* OTel span attributes for this intent
+                try:
+                    from opentelemetry import trace as _trace
+                    from petrosa_otel import set_decision_context
+
+                    set_decision_context(
+                        _trace.get_current_span(),
+                        intent_id=signal.intent_id,
+                        strategy_id=signal.strategy_id,
+                        symbol=signal.symbol,
+                        action=signal.action,
+                        confidence=signal.confidence,
+                    )
+                except ImportError:
+                    pass
+                except Exception as _exc:
+                    logger.debug("set_decision_context failed: %s", _exc)
+
                 # DEBUG: Log the signal data including stop_loss/take_profit
                 logger.info(
                     f"🔍 DEBUG SIGNAL DATA: {signal.strategy_id} | "


### PR DESCRIPTION
## Summary
- Adds `intent_id` (uuid4 hex) field to `Signal` model for per-intent traceability
- `publisher._publish_via_nats()` calls `set_decision_context()` after NATS trace injection to propagate `decision.*` OTel span attributes
- Requires `petrosa-otel>=1.0.6` (see petrosa_k8s#581)

Closes petrosa_k8s#580

## Test plan
- [ ] 346 ta_bot tests pass (1 pre-existing MongoDB failure unrelated to this change)
- [ ] Verify `Signal.intent_id` is auto-generated as 32-char hex string
- [ ] Verify `Signal.to_dict()` includes `intent_id`
- [ ] Verify OTel span attributes set on publish via NATS

🤖 Generated with [Claude Code](https://claude.com/claude-code)