### PR TITLE
[FIX] Remove signal_count histogram label (cardinality fix)

### DIFF
--- a/ta_bot/core/signal_engine.py
+++ b/ta_bot/core/signal_engine.py
@@ -259,7 +259,7 @@ class SignalEngine:
             # Record processing latency metric
             self.signal_latency.record(
                 duration_ms,
-                {"symbol": symbol, "timeframe": period, "signal_count": len(signals)},
+                {"symbol": symbol, "timeframe": period},
             )
 
             # Add final span attributes


### PR DESCRIPTION
## Summary

Removes `signal_count` from the `ta_bot.signal.processing_duration` histogram's label set.

### Problem
`signal_count` (an integer observation) was used as a Prometheus label on the histogram, multiplying series by bucket count (×16). This single metric generated ~3,744 series — 42% of Grafana Cloud's 10k free-tier limit.

### Change
Removed `signal_count` key from the `self.signal_latency.record()` attributes dict in `ta_bot/core/signal_engine.py`. The observation value is already captured in the histogram value itself; it does not need to be a label dimension.

### Expected impact
- `ta_bot_signal_processing_duration_milliseconds_bucket` series count: ~3,744 → ~374 (10× reduction)
- ~3,370 Grafana Cloud series freed

### Related
- Closes #236
- Part of cardinality audit from #660
- Companion PR: [petrosa_k8s alloy config patch](https://github.com/PetroSa2/petrosa_k8s/compare/fix/236-strip-service-version-alloy-otlp)

### Checklist
- [x] `signal_count` label removed from histogram recording
- [x] Ruff lint passes
- [x] All 600 tests pass (5 skipped)
- [x] Pre-existing 110 mypy errors confirmed pre-existing (same count before/after change)