### PR TITLE
[BUG] bot-ta-analysis version label appends across deploys — 172-char label blocks all bot-ta-analysis applies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,8 @@ jobs:
       run: |
         # Get latest tag, default to v1.0.0 if no tags exist
         CURRENT=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
-        BASE_VERSION="${CURRENT}"
+        BASE_VERSION=$(echo "$CURRENT" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
+        : "${BASE_VERSION:=v1.0.0}"
         SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
         VERSION="${BASE_VERSION}-r${{ github.run_number }}-${SHORT_SHA}"
         echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes the version label overflow bug where each deploy appended a `-rNN-SHA` suffix on top of the previously-bloated tag returned by `git describe`, eventually exceeding Kubernetes' 63-char label limit.

## Root cause

`git describe --tags --abbrev=0` was returning the previously-pushed compound tag (e.g. `v1.0.0-r39-...-r48-...`), causing the next run to compose an even longer version string.

## Fix

Strip to the base semver component before composing VERSION:
```bash
BASE_VERSION=$(echo "$CURRENT" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
: "${BASE_VERSION:=v1.0.0}"
```

## Related

- Closes [PetroSa2/petrosa_k8s#681](https://github.com/PetroSa2/petrosa_k8s/issues/681)
- Companion k8s manifest reset: PetroSa2/petrosa_k8s (branch fix/681-k8s-manifest-reset)

## Acceptance criteria

- [x] deploy.yml: strip base semver before composing VERSION
- [ ] Verify next release produces version label ≤ 63 chars (CI gate post-merge)