### PR TITLE
fix(lifecycle): wire _ensure_lifecycle_index into _create_indexes startup path

### DIFF
--- a/ta_bot/db/mongodb_client.py
+++ b/ta_bot/db/mongodb_client.py
@@ -192,6 +192,9 @@ class MongoDBClient:
                 [("changed_at", -1)]  # Descending for recent-first queries
             )
 
+            # Strategy lifecycle events: compound index for history queries
+            await self._ensure_lifecycle_index()
+
             logger.info("MongoDB indexes created successfully")
 
         except Exception as e:


### PR DESCRIPTION
## Summary

- `_ensure_lifecycle_index()` was added in PR #244 but never called — the compound index on `strategy_lifecycle_events(strategy_id, transitioned_at)` was never being created at startup
- Wired it into `_create_indexes()` alongside all other collection indexes; no behaviour change except the index now exists

## Test plan

- [x] `pytest tests/test_lifecycle.py` — 16/16 pass
- [x] `ruff check` — clean

Closes follow-up from #241 code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)