### PR TITLE
feat: 239 - add HTTP API trigger surface for backtests (FR2)

### DIFF
--- a/docs/BACKTEST.md
+++ b/docs/BACKTEST.md
@@ -38,6 +38,57 @@ Flags:
 | `--output` | no | stdout | Where to write the artifact JSON |
 | `--log-level` | no | `INFO` | `DEBUG\|INFO\|WARNING\|ERROR` |
 
+## HTTP API trigger (P3.1-FU, #239)
+
+Beyond the CLI, backtests can be launched over HTTP — for schedulers, operators,
+or other services — via the FastAPI app on port 8000:
+
+```bash
+curl -sX POST http://localhost:8000/api/v1/backtest \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "strategy_id": "ema_alignment_bullish",
+        "from": "2026-01-01T00:00:00",
+        "to": "2026-12-31T00:00:00",
+        "symbol": "BTCUSDT",
+        "period": "15m",
+        "warmup": 200,
+        "persist": true
+      }'
+```
+
+The endpoint reuses the **same `BacktestEngine` and `ArtifactPersister`** as
+`python -m backtest`, so the emitted `CharacterizationArtifact` is byte-for-byte
+the same shape (FR3 / P3.2 contract). On success it returns the standard
+`APIResponse` envelope with a run summary (`candle_count`, `signal_count`,
+`source`, `persisted`); the full artifact is written to the data-manager
+`characterization_artifacts` collection when `persist` is `true` (default).
+
+| field | required | default | meaning |
+| --- | --- | --- | --- |
+| `strategy_id` | yes | — | Registered strategy_id |
+| `from` / `to` | yes | — | ISO-8601 window bounds (UTC if no tz) |
+| `symbol` | no | `BTCUSDT` | Trading symbol |
+| `period` | no | `15m` | Candle period |
+| `warmup` | no | `200` | Candles required before strategies evaluate |
+| `max_candles` | no | `1000` | Cap on data-manager fetches |
+| `persist` | no | `true` | Persist the artifact to petrosa-data-manager |
+| `parameter_overrides` | no | — | Reserved; not yet applied by the engine (HTTP 422 if supplied) |
+
+A k8s `CronJob` schedule was the alternative trigger surface considered for
+#239; the HTTP API was chosen because it is self-contained in this service,
+needs no manifest wiring, and can itself be driven by a future `CronJob` that
+simply `curl`s this endpoint.
+
+### `petrosa-realtime-strategies` decision (AC3)
+
+`petrosa-realtime-strategies` does **not** get its own backtest path. Its
+strategies are backtested **through `petrosa-bot-ta-analysis`** — the backtest
+engine composes `ta_bot.core.signal_engine.SignalEngine`, which is the single
+strategy registry for both live and offline replay (per architecture §9.4). Any
+strategy registered there is immediately backtestable via this endpoint with no
+extra wiring, so a second engine in realtime-strategies would only risk drift.
+
 ## Artifact schema (v1.0.0)
 
 ```json

--- a/ta_bot/api/backtest_routes.py
+++ b/ta_bot/api/backtest_routes.py
@@ -1,0 +1,168 @@
+"""FastAPI route for triggering backtests over HTTP (FR2 / #239).
+
+P3.1 (#234) shipped the backtest engine with a CLI surface only. This module
+adds an HTTP API trigger surface so backtests can be launched by schedulers,
+operators, or other services without a shell. The endpoint reuses the exact
+same `BacktestEngine` + `ArtifactPersister` path as `python -m backtest`, so the
+produced `CharacterizationArtifact` is identical to the CLI's (FR3 / P3.2
+contract) — there is no parallel backtest implementation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+
+from ta_bot.api.response_models import APIResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class BacktestTriggerRequest(BaseModel):
+    """Payload for POST /api/v1/backtest."""
+
+    strategy_id: str = Field(..., description="Registered strategy_id to replay")
+    range_from: datetime = Field(
+        ...,
+        alias="from",
+        description="ISO-8601 start of the candle window (UTC assumed if naive)",
+    )
+    range_to: datetime = Field(
+        ...,
+        alias="to",
+        description="ISO-8601 end of the candle window (UTC assumed if naive)",
+    )
+    symbol: str = Field("BTCUSDT", description="Trading symbol")
+    period: str = Field("15m", description="Candle period")
+    warmup: int = Field(
+        200, ge=1, description="Minimum candles before strategies are evaluated"
+    )
+    max_candles: int = Field(
+        1000, ge=1, description="Cap on data-manager candle fetches"
+    )
+    persist: bool = Field(
+        True, description="Persist the artifact to petrosa-data-manager after the run"
+    )
+    parameter_overrides: dict[str, Any] | None = Field(
+        None,
+        description=(
+            "Reserved for per-run strategy parameter overrides. The engine "
+            "currently replays the registered strategy parameters and does not "
+            "yet apply overrides; supplying a non-empty value returns HTTP 422."
+        ),
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+class BacktestTriggerResponse(BaseModel):
+    """Summary of a triggered backtest run (the full artifact is persisted)."""
+
+    strategy_id: str
+    symbol: str
+    period: str
+    range_from: str
+    range_to: str
+    candle_count: int
+    signal_count: int
+    schema_version: str
+    source: str
+    persisted: bool
+
+
+@router.post(
+    "/backtest",
+    response_model=APIResponse[BacktestTriggerResponse],
+    summary="Trigger a backtest run over HTTP",
+    description=(
+        "Replays a registered TA strategy against historical candles from "
+        "petrosa-data-manager and emits a CharacterizationArtifact — the same "
+        "engine and artifact contract as `python -m backtest`. When `persist` is "
+        "true (default) the artifact is written to the data-manager "
+        "`characterization_artifacts` collection."
+    ),
+)
+async def trigger_backtest(
+    payload: BacktestTriggerRequest,
+) -> APIResponse[BacktestTriggerResponse]:
+    range_from = payload.range_from
+    if range_from.tzinfo is None:
+        range_from = range_from.replace(tzinfo=UTC)
+    range_to = payload.range_to
+    if range_to.tzinfo is None:
+        range_to = range_to.replace(tzinfo=UTC)
+
+    if range_to < range_from:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="'to' must be on or after 'from'",
+        )
+    if payload.parameter_overrides:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "parameter_overrides is accepted by the API contract but not yet "
+                "applied by the backtest engine; omit it until engine support lands"
+            ),
+        )
+
+    from backtest.data_source import DataManagerHistoricalSource
+    from backtest.engine import BacktestEngine, BacktestRequest
+
+    engine = BacktestEngine(
+        data_source=DataManagerHistoricalSource(max_candles=payload.max_candles)
+    )
+    request = BacktestRequest(
+        strategy_id=payload.strategy_id,
+        symbol=payload.symbol,
+        period=payload.period,
+        range_from=range_from,
+        range_to=range_to,
+        warmup=payload.warmup,
+    )
+
+    try:
+        # engine.run is synchronous (pandas + indicator math); keep the event
+        # loop responsive by running it in a worker thread.
+        artifact = await asyncio.to_thread(engine.run, request)
+    except ValueError as exc:
+        # Unknown strategy_id / invalid warmup — a client error.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Backtest run failed for %s", payload.strategy_id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"backtest failed: {exc}",
+        ) from exc
+
+    persisted = False
+    if payload.persist:
+        from backtest.persistence import ArtifactPersister
+
+        persisted = await ArtifactPersister().apersist(artifact)
+
+    return APIResponse(
+        success=True,
+        data=BacktestTriggerResponse(
+            strategy_id=artifact.strategy_id,
+            symbol=artifact.symbol,
+            period=artifact.period,
+            range_from=artifact.range_from,
+            range_to=artifact.range_to,
+            candle_count=artifact.candle_count,
+            signal_count=artifact.signal_count,
+            schema_version=artifact.schema_version,
+            source=artifact.source,
+            persisted=persisted,
+        ),
+        metadata={"persisted": persisted, "requested_persist": payload.persist},
+    )

--- a/ta_bot/health.py
+++ b/ta_bot/health.py
@@ -64,6 +64,15 @@ try:
 except Exception as e:
     logger.warning(f"Could not register configuration API routes: {e}")
 
+# Register backtest trigger API route (FR2 / #239)
+try:
+    from ta_bot.api.backtest_routes import router as backtest_router
+
+    app.include_router(backtest_router, prefix="/api/v1")
+    logger.info("Backtest API route registered at /api/v1/backtest")
+except Exception as e:
+    logger.warning(f"Could not register backtest API route: {e}")
+
 # Register lifecycle manager with API routes (FR9)
 try:
     import os

--- a/tests/test_backtest_api.py
+++ b/tests/test_backtest_api.py
@@ -1,0 +1,138 @@
+"""HTTP backtest trigger endpoint tests (#239, FR2).
+
+Drives the real BacktestEngine over the recorded 260-candle fixture through the
+FastAPI endpoint and asserts the CharacterizationArtifact is persisted to
+petrosa-data-manager (AC5). Persistence is mocked at the data-manager boundary
+so the test needs no external services; the data source is swapped for the
+recorded fixture so the engine runs end-to-end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backtest.artifact import CharacterizationArtifact
+from backtest.data_source import FixtureHistoricalSource
+from ta_bot.health import app
+
+FIXTURE_PATH = (
+    Path(__file__).parent
+    / "backtest"
+    / "fixtures"
+    / "candles_BTCUSDT_15m_recorded.json"
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _fixture_source(*_args, **_kwargs) -> FixtureHistoricalSource:
+    """Stand in for DataManagerHistoricalSource so the engine replays the fixture."""
+    return FixtureHistoricalSource(FIXTURE_PATH)
+
+
+def test_trigger_backtest_runs_engine_and_persists(client: TestClient) -> None:
+    persist_mock = AsyncMock(return_value=True)
+    with (
+        patch("backtest.data_source.DataManagerHistoricalSource", _fixture_source),
+        patch("backtest.persistence.ArtifactPersister.apersist", persist_mock),
+    ):
+        resp = client.post(
+            "/api/v1/backtest",
+            json={
+                "strategy_id": "ema_alignment_bullish",
+                "from": "2026-01-01T00:00:00",
+                "to": "2026-12-31T00:00:00",
+                "symbol": "BTCUSDT",
+                "period": "15m",
+                "warmup": 125,
+                "persist": True,
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["success"] is True
+    data = body["data"]
+    assert data["strategy_id"] == "ema_alignment_bullish"
+    assert data["symbol"] == "BTCUSDT"
+    assert data["source"] == "backtest"
+    assert data["candle_count"] == 260
+    assert data["signal_count"] > 0
+    assert data["persisted"] is True
+
+    # AC5: the artifact was handed to the data-manager persister.
+    persist_mock.assert_awaited_once()
+    persisted_artifact = persist_mock.await_args.args[0]
+    assert isinstance(persisted_artifact, CharacterizationArtifact)
+    assert persisted_artifact.strategy_id == "ema_alignment_bullish"
+    assert persisted_artifact.source == "backtest"
+
+
+def test_trigger_backtest_can_skip_persistence(client: TestClient) -> None:
+    persist_mock = AsyncMock(return_value=True)
+    with (
+        patch("backtest.data_source.DataManagerHistoricalSource", _fixture_source),
+        patch("backtest.persistence.ArtifactPersister.apersist", persist_mock),
+    ):
+        resp = client.post(
+            "/api/v1/backtest",
+            json={
+                "strategy_id": "ema_alignment_bullish",
+                "from": "2026-01-01T00:00:00",
+                "to": "2026-12-31T00:00:00",
+                "warmup": 125,
+                "persist": False,
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"]["persisted"] is False
+    persist_mock.assert_not_awaited()
+
+
+def test_trigger_backtest_unknown_strategy_returns_422(client: TestClient) -> None:
+    with patch("backtest.data_source.DataManagerHistoricalSource", _fixture_source):
+        resp = client.post(
+            "/api/v1/backtest",
+            json={
+                "strategy_id": "no_such_strategy",
+                "from": "2026-01-01T00:00:00",
+                "to": "2026-12-31T00:00:00",
+                "warmup": 60,
+            },
+        )
+    assert resp.status_code == 422
+    assert "no_such_strategy" in resp.text
+
+
+def test_trigger_backtest_rejects_parameter_overrides(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/backtest",
+        json={
+            "strategy_id": "ema_alignment_bullish",
+            "from": "2026-01-01T00:00:00",
+            "to": "2026-12-31T00:00:00",
+            "parameter_overrides": {"rsi_oversold": 25},
+        },
+    )
+    assert resp.status_code == 422
+    assert "parameter_overrides" in resp.text
+
+
+def test_trigger_backtest_to_before_from_returns_422(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/backtest",
+        json={
+            "strategy_id": "ema_alignment_bullish",
+            "from": "2026-12-31T00:00:00",
+            "to": "2026-01-01T00:00:00",
+        },
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Implements `PetroSa2/petrosa-bot-ta-analysis#239` — adds an **HTTP API trigger surface** for the backtest engine (which P3.1/#234 shipped CLI-only), so FR2 can move toward GREEN. Per the operator decision, the HTTP-API path was chosen over a k8s CronJob (self-contained, no manifest wiring, and a future CronJob can simply `curl` this endpoint).

- **`ta_bot/api/backtest_routes.py`** (new) — `POST /api/v1/backtest` accepting `{strategy_id, from, to, symbol?, period?, warmup?, max_candles?, persist?, parameter_overrides?}`. It reuses the **exact same** `BacktestEngine` + `DataManagerHistoricalSource` + `ArtifactPersister` as `python -m backtest`, so the produced `CharacterizationArtifact` is identical (FR3 / P3.2 contract). The synchronous engine runs via `asyncio.to_thread` to keep the event loop responsive. Returns the standard `APIResponse` envelope with a run summary.
- **`ta_bot/health.py`** — registers the new router on the existing FastAPI app at `/api/v1` (mirrors the config-routes registration).
- **`tests/test_backtest_api.py`** (new) — drives the real engine end-to-end over the recorded 260-candle fixture through the endpoint and asserts the artifact is persisted (persistence mocked at the data-manager boundary), plus validation cases.
- **`docs/BACKTEST.md`** — documents the HTTP trigger surface and the AC3 realtime-strategies decision.

## Acceptance criteria

- ✅ **AC1** — HTTP endpoint on bot-ta-analysis accepting `{strategy_id, from, to, parameter_overrides}` (+ symbol/period/warmup/persist), running the same backtest engine as the CLI. `parameter_overrides` is accepted by the contract but the engine does not yet apply overrides, so a non-empty value returns HTTP 422 (documented) rather than silently ignoring it.
- ✅ **AC2** — Output unchanged: same `BacktestEngine`/`ArtifactPersister` path → identical `CharacterizationArtifact` shape.
- ✅ **AC3** — `petrosa-realtime-strategies` decision documented in `docs/BACKTEST.md`: it does **not** get its own backtest path; its strategies are backtested through bot-ta-analysis (single `SignalEngine` registry, per architecture §9.4). Cross-service flow documented.
- ⏳ **AC4** — FR2 → GREEN in the next reality-check snapshot. This is a doc update in **petrosa_k8s** (the reality-check artifact lives there), so it is **out of this repo's PR**; tracked as a follow-up with this endpoint as the evidence link. (Flagged in the issue thread.)
- ✅ **AC5** — Integration test runs an end-to-end backtest via the triggered surface and asserts the artifact is persisted to petrosa-data-manager (`ArtifactPersister.apersist` invoked with the `CharacterizationArtifact`; data-manager boundary mocked so CI needs no external service).

## Scope notes

- Single-repo change (bot-ta-analysis). The k8s CronJob alternative and the petrosa_k8s reality-check doc (AC4) are intentionally left out to keep the PR tight; both are documented as follow-ups.
- No existing backtest behaviour changes — the CLI path is untouched.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy ta_bot/api/backtest_routes.py` — no errors in the new file (pre-existing config_routes errors are unrelated; mypy non-blocking in CI)
- [x] `pytest tests/test_backtest_api.py` — 5 passed
- [x] full suite — 646 passed, 5 skipped; coverage 79% (threshold 18%)
- [ ] post-deploy: trigger a real backtest via the endpoint and confirm the artifact lands in data-manager `characterization_artifacts`

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
