### PR TITLE
feat: bot-ta-analysis evaluator producer — publish evaluator.bot-ta-analysis.verdict (#248)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ opentelemetry-semantic-conventions>=0.41b0
 pandas>=2.0.0
 
 # Petrosa OTel package
-petrosa-otel[all]>=1.0.6
+petrosa-otel[all]>=1.1.0
 prometheus-client>=0.17.0
 pydantic>=2.0.0
 pydantic-settings>=2.0.0

--- a/ta_bot/evaluators/__init__.py
+++ b/ta_bot/evaluators/__init__.py
@@ -1,0 +1,17 @@
+"""bot-ta-analysis subsystem evaluator (P2.7, petrosa_k8s#697 AC4 / #248).
+
+Adopts the shared `petrosa_otel.evaluators` framework (P2.1) so bot-ta-analysis
+publishes a structured health verdict on ``evaluator.bot-ta-analysis.verdict``,
+closing one of the five "silent service" gaps that keep FR17 / FR23 / FR32 at
+YELLOW.
+"""
+
+from ta_bot.evaluators.health_evaluator import (
+    BotTaAnalysisHealthEvaluator,
+    build_bot_ta_analysis_health_evaluator,
+)
+
+__all__ = [
+    "BotTaAnalysisHealthEvaluator",
+    "build_bot_ta_analysis_health_evaluator",
+]

--- a/ta_bot/evaluators/health_evaluator.py
+++ b/ta_bot/evaluators/health_evaluator.py
@@ -1,0 +1,247 @@
+"""bot-ta-analysis health evaluator (P2.7, petrosa_k8s#697 AC4 / #248).
+
+Emits ``evaluator.bot-ta-analysis.verdict`` via the shared P2.1 framework
+(:mod:`petrosa_otel.evaluators`) so the operator dashboard's evaluator strip
+counts bot-ta-analysis among the reporting subsystems (FR17 / FR23 / FR32).
+
+The verdict combines three health signals sampled from the running
+``NATSListener`` (which owns the signal engine, candle data client, and the
+signal publisher) on each emit tick:
+
+1. **Indicator-compute latency** — rolling mean of the per-extraction
+   ``analyze_candles`` duration. A sustained high value means the strategy
+   computation is degrading (slow MySQL reads, CPU starvation, etc.).
+2. **MySQL connection health** — whether the most recent candle-data fetch
+   succeeded. Repeated fetch failures mean the candle source (direct MySQL or
+   the Data Manager fronting it) is unreachable, so no analysis can run.
+3. **Signal-emission rate** — outbound signal count. TA signals are sparse
+   (emitted only on candle-close extraction events), so the collapse check
+   stays dormant until a meaningful emission baseline is established; it then
+   trips if emission falls to a small fraction of that baseline.
+
+Verdict vocabulary is the framework's locked three-state contract
+(``healthy`` / ``unhealthy`` / ``unknown``); there is no separate ``degraded``
+state, so any breached signal maps to ``unhealthy`` and the reason string names
+which signal tripped (NFR-O5 verbatim render).
+
+Hysteresis / cadence (AC4 / AC7, FR18 per-evaluator ``decision_window``): emits
+every ``EMIT_INTERVAL_S`` (15s) and, via ``ConsecutiveSamplesHysteresis(n=3)``,
+only flips the published verdict after 3 consecutive matching samples (~45s
+decision window). Signals are bursty (extraction events are periodic), so
+smoothing avoids flapping while a sustained problem surfaces within ~45s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from collections.abc import Callable
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+from petrosa_otel.evaluators import (
+    ConsecutiveSamplesHysteresis,
+    Evaluator,
+    NatsVerdictPublisher,
+)
+
+if TYPE_CHECKING:
+    from petrosa_otel.evaluators.base import HysteresisPolicy
+    from petrosa_otel.evaluators.publisher import VerdictPublisher
+
+logger = logging.getLogger(__name__)
+
+SUBSYSTEM = "bot-ta-analysis"
+
+# Cadence + smoothing (documented per AC4 / AC7).
+EMIT_INTERVAL_S = 15.0
+HYSTERESIS_SAMPLES = 3
+
+# Indicator-compute latency: analyze_candles runs several strategies over ~250
+# candles; a sustained mean above 5s indicates degraded computation (slow data
+# reads, CPU starvation) rather than a single slow run.
+DEFAULT_LATENCY_THRESHOLD_S = 5.0
+# Signal-emission collapse: once a meaningful baseline exists, dropping below
+# 10% of it means the analysis pipeline stalled.
+DEFAULT_SIGNAL_COLLAPSE_RATIO = 0.1
+# Minimum baseline emission rate (signals/s) before the collapse check may
+# trip. TA signals are sparse (candle-close driven), so a near-zero baseline
+# keeps the check dormant.
+DEFAULT_MIN_SIGNAL_RATE = 0.02
+# Rolling baseline window (8 samples ≈ 2 min at 15s).
+DEFAULT_BASELINE_WINDOW = 8
+DEFAULT_MIN_BASELINE_SAMPLES = 4
+
+
+class BotTaAnalysisHealthEvaluator(Evaluator):
+    """Subsystem evaluator for bot-ta-analysis compute→signal health."""
+
+    def __init__(
+        self,
+        *,
+        metrics_source: Callable[[], dict[str, Any]],
+        publisher: VerdictPublisher | None = None,
+        hysteresis: HysteresisPolicy | None = None,
+        latency_threshold_s: float = DEFAULT_LATENCY_THRESHOLD_S,
+        signal_collapse_ratio: float = DEFAULT_SIGNAL_COLLAPSE_RATIO,
+        min_signal_rate: float = DEFAULT_MIN_SIGNAL_RATE,
+        baseline_window: int = DEFAULT_BASELINE_WINDOW,
+        min_baseline_samples: int = DEFAULT_MIN_BASELINE_SAMPLES,
+        emit_interval_s: float = EMIT_INTERVAL_S,
+        time_source: Callable[[], datetime] | None = None,
+    ) -> None:
+        super().__init__(
+            subsystem=SUBSYSTEM,
+            publisher=publisher,
+            hysteresis=hysteresis or ConsecutiveSamplesHysteresis(n=HYSTERESIS_SAMPLES),
+        )
+        self._metrics_source = metrics_source
+        self._latency_threshold_s = latency_threshold_s
+        self._signal_collapse_ratio = signal_collapse_ratio
+        self._min_signal_rate = min_signal_rate
+        self._min_baseline_samples = max(1, min_baseline_samples)
+        self._emit_interval_s = emit_interval_s
+        self._time = time_source or (lambda: datetime.now(UTC))
+
+        self._signal_baseline: deque[float] = deque(maxlen=max(1, baseline_window))
+        self._prev_signals: int | None = None
+        self._prev_sample_at: datetime | None = None
+
+        self._emit_task: asyncio.Task[Any] | None = None
+
+    # ----- lifecycle -----
+
+    async def start(self) -> None:
+        """Start the periodic emit loop (idempotent)."""
+        if self._emit_task is not None:
+            return
+        self._emit_task = asyncio.create_task(self._emit_loop())
+        logger.info(
+            "bot_ta_analysis_health_evaluator_started",
+            extra={"subsystem": SUBSYSTEM, "emit_interval_s": self._emit_interval_s},
+        )
+
+    async def stop(self) -> None:
+        """Stop the emit loop."""
+        if self._emit_task is None:
+            return
+        self._emit_task.cancel()
+        try:
+            await self._emit_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"bot_ta_analysis_health_evaluator stop error: {exc}")
+        self._emit_task = None
+
+    async def _emit_loop(self) -> None:
+        while True:
+            try:
+                await self.tick()
+            except Exception as exc:  # noqa: BLE001 — never crash the loop
+                logger.warning(
+                    "bot_ta_analysis_health_evaluator_tick_failed",
+                    extra={"error": str(exc)},
+                )
+            await asyncio.sleep(self._emit_interval_s)
+
+    # ----- framework hook -----
+
+    async def evaluate(self) -> tuple[str, str]:
+        """Compute the raw ``(verdict, reason)`` sample for the current state."""
+        snapshot = self._metrics_source()
+        now = self._time()
+
+        signals = int(snapshot.get("signals_emitted", 0) or 0)
+        latency_s = float(snapshot.get("analysis_latency_s", 0.0) or 0.0)
+        nats_connected = bool(snapshot.get("nats_connected"))
+        mysql_healthy = bool(snapshot.get("mysql_healthy", True))
+
+        prev_signals = self._prev_signals
+        prev_at = self._prev_sample_at
+
+        self._prev_signals = signals
+        self._prev_sample_at = now
+
+        if prev_signals is None or prev_at is None:
+            return "unknown", "establishing baseline (first sample)"
+
+        if signals < prev_signals:
+            self._signal_baseline.clear()
+            return "unknown", "counter reset detected; rebaselining"
+
+        # 1) Connectivity is the dominant signal.
+        if not nats_connected:
+            return "unhealthy", "NATS publisher disconnected; cannot emit signals"
+
+        # 2) MySQL / candle-data connection health.
+        if not mysql_healthy:
+            return "unhealthy", "candle-data source unreachable (MySQL/Data Manager)"
+
+        # 3) Indicator-compute latency.
+        if latency_s > self._latency_threshold_s:
+            return (
+                "unhealthy",
+                f"indicator-compute latency {latency_s:.1f}s > "
+                f"{self._latency_threshold_s:.1f}s threshold",
+            )
+
+        # 4) Signal-emission rate vs baseline (dormant until a real baseline).
+        interval_s = (now - prev_at).total_seconds()
+        signal_rate = (signals - prev_signals) / interval_s if interval_s > 0 else 0.0
+        if (
+            len(self._signal_baseline) >= self._min_baseline_samples
+            and self._signal_baseline
+        ):
+            sig_baseline_mean = sum(self._signal_baseline) / len(self._signal_baseline)
+            if (
+                sig_baseline_mean >= self._min_signal_rate
+                and signal_rate < self._signal_collapse_ratio * sig_baseline_mean
+            ):
+                self._signal_baseline.append(signal_rate)
+                return (
+                    "unhealthy",
+                    f"signal emission collapsed: {signal_rate:.3f}/s vs baseline "
+                    f"{sig_baseline_mean:.3f}/s",
+                )
+        self._signal_baseline.append(signal_rate)
+
+        return (
+            "healthy",
+            f"compute {latency_s:.2f}s, {signal_rate:.3f} signals/s, MySQL ok",
+        )
+
+
+def build_bot_ta_analysis_health_evaluator(
+    nats_listener: Any,
+) -> BotTaAnalysisHealthEvaluator | None:
+    """Construct an evaluator sourcing from a started ``NATSListener``.
+
+    Publishes verdicts on the listener's signal publisher's NATS connection.
+    Returns ``None`` if that publisher has no live NATS client. Call after
+    ``nats_listener.start()``.
+    """
+    publisher = getattr(nats_listener, "publisher", None)
+    nats_client = getattr(publisher, "nats_client", None) if publisher else None
+    if nats_client is None:
+        logger.warning(
+            "bot_ta_analysis_health_evaluator not started: no NATS client available"
+        )
+        return None
+
+    def _snapshot() -> dict[str, Any]:
+        return nats_listener.get_health_metrics()
+
+    verdict_publisher = NatsVerdictPublisher(nats_client=nats_client)
+    return BotTaAnalysisHealthEvaluator(
+        metrics_source=_snapshot,
+        publisher=verdict_publisher,
+    )

--- a/ta_bot/main.py
+++ b/ta_bot/main.py
@@ -222,8 +222,27 @@ async def main():
                 )
             logger.info("✅ Publisher NATS connection verified successfully")
 
+            # Start health evaluator (publishes evaluator.bot-ta-analysis.verdict).
+            # Optional: skipped if petrosa-otel lacks the evaluators framework.
+            health_evaluator = None
+            try:
+                from ta_bot.evaluators import build_bot_ta_analysis_health_evaluator
+
+                health_evaluator = build_bot_ta_analysis_health_evaluator(nats_listener)
+                if health_evaluator is not None:
+                    await health_evaluator.start()
+                    logger.info("Health evaluator started")
+            except ImportError:
+                logger.warning(
+                    "petrosa_otel.evaluators unavailable; health evaluator disabled"
+                )
+
             # Wait for health task to keep the application running
-            await health_task
+            try:
+                await health_task
+            finally:
+                if health_evaluator is not None:
+                    await health_evaluator.stop()
         else:
             logger.info("NATS is disabled, skipping NATS listener startup")
             # Keep the application running for health checks

--- a/ta_bot/services/nats_listener.py
+++ b/ta_bot/services/nats_listener.py
@@ -5,6 +5,8 @@ NATS listener service for receiving candle data and processing signals.
 import asyncio
 import json
 import logging
+import time
+from collections import deque
 from typing import Any
 
 from nats.aio.client import Client as NATS
@@ -56,6 +58,11 @@ class NATSListener:
         self.subscriptions: list[Any] = []
         self.leader_election = None
         self.mysql_client = MySQLClient()
+
+        # Health signals consumed by BotTaAnalysisHealthEvaluator (P2.7 #248).
+        self._recent_analysis_latencies: deque[float] = deque(maxlen=200)
+        self.signals_emitted = 0
+        self._mysql_healthy = True
 
     async def start(self):
         """Start the NATS listener."""
@@ -213,7 +220,15 @@ class NATSListener:
             logger.info(f"Processing extraction completion for {symbol} {period}")
 
             # Fetch candle data from MySQL (250 candles needed for EMA200)
-            df = await self.mysql_client.fetch_candles(symbol, period, limit=250)
+            try:
+                df = await self.mysql_client.fetch_candles(symbol, period, limit=250)
+                self._mysql_healthy = True
+            except Exception as fetch_exc:
+                self._mysql_healthy = False
+                logger.error(
+                    f"Candle-data fetch failed for {symbol} {period}: {fetch_exc}"
+                )
+                return
 
             if df is None or len(df) == 0:
                 logger.warning(f"No candle data available for {symbol} {period}")
@@ -235,6 +250,7 @@ class NATSListener:
             # Run CPU-bound pandas/numpy computation in a thread pool executor to avoid
             # blocking the asyncio event loop and causing readiness probe timeouts.
             loop = asyncio.get_running_loop()
+            _analysis_start = time.perf_counter()
             signals = await loop.run_in_executor(
                 None,
                 lambda: self.signal_engine.analyze_candles(
@@ -245,6 +261,9 @@ class NATSListener:
                     min_confidence=min_confidence,
                     max_confidence=max_confidence,
                 ),
+            )
+            self._recent_analysis_latencies.append(
+                time.perf_counter() - _analysis_start
             )
 
             if signals:
@@ -274,6 +293,7 @@ class NATSListener:
                     f"🚀 PUBLISHING {len(signals)} signals to Trade Engine via publisher"
                 )
                 await self.publisher.publish_signals(signals)
+                self.signals_emitted += len(signals)
                 logger.info(f"✅ Publisher call completed for {len(signals)} signals")
 
             else:
@@ -282,6 +302,19 @@ class NATSListener:
                 )
         except Exception as e:
             logger.error(f"Error processing symbol {symbol} {period}: {e}")
+
+    def get_health_metrics(self) -> dict[str, Any]:
+        """Expose readable health signals for BotTaAnalysisHealthEvaluator (#248)."""
+        pub_client = getattr(self.publisher, "nats_client", None)
+        latencies = self._recent_analysis_latencies
+        return {
+            "nats_connected": bool(pub_client and pub_client.is_connected),
+            "mysql_healthy": self._mysql_healthy,
+            "analysis_latency_s": (
+                sum(latencies) / len(latencies) if latencies else 0.0
+            ),
+            "signals_emitted": self.signals_emitted,
+        }
 
     async def _cleanup(self):
         """Clean up NATS connections and subscriptions."""

--- a/tests/test_nats_listener_service.py
+++ b/tests/test_nats_listener_service.py
@@ -285,3 +285,64 @@ class TestNATSListener:
 
                 nats_listener.publisher.stop.assert_called_once()
                 mock_nats_client.close.assert_called_once()
+
+    async def test_get_health_metrics(self, nats_listener):
+        """get_health_metrics exposes the evaluator signal snapshot (#248)."""
+        nats_listener.publisher.nats_client = MagicMock()
+        nats_listener.publisher.nats_client.is_connected = True
+        nats_listener.signals_emitted = 7
+        nats_listener._mysql_healthy = True
+        nats_listener._recent_analysis_latencies.extend([1.0, 3.0])
+
+        metrics = nats_listener.get_health_metrics()
+
+        assert metrics["nats_connected"] is True
+        assert metrics["mysql_healthy"] is True
+        assert metrics["signals_emitted"] == 7
+        assert metrics["analysis_latency_s"] == 2.0
+
+    async def test_get_health_metrics_no_nats(self, nats_listener):
+        """get_health_metrics reports disconnected when no NATS client (#248)."""
+        nats_listener.publisher.nats_client = None
+        metrics = nats_listener.get_health_metrics()
+        assert metrics["nats_connected"] is False
+        assert metrics["analysis_latency_s"] == 0.0
+
+    async def test_process_extraction_fetch_failure_sets_unhealthy(self, nats_listener):
+        """A candle-fetch exception flips mysql_healthy to False (#248)."""
+        nats_listener._mysql_healthy = True
+        with patch.object(
+            nats_listener.mysql_client,
+            "fetch_candles",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("db down"),
+        ):
+            await nats_listener._process_symbol_extraction("BTCUSDT", "15m")
+
+        assert nats_listener._mysql_healthy is False
+
+    async def test_process_extraction_success_tracks_signals(self, nats_listener):
+        """A successful extraction records latency and increments signals_emitted (#248)."""
+        df = pd.DataFrame({"close": [1.0, 2.0, 3.0]})
+        sig = MagicMock()
+        sig.to_dict.return_value = {"strategy_id": "s", "action": "buy"}
+        nats_listener.signal_engine.analyze_candles.return_value = [sig]
+        nats_listener.publisher.publish_signals = AsyncMock()
+
+        with patch.object(
+            nats_listener.mysql_client,
+            "fetch_candles",
+            new_callable=AsyncMock,
+            return_value=df,
+        ):
+            with patch.object(
+                nats_listener.mysql_client,
+                "persist_signals_batch",
+                new_callable=AsyncMock,
+                return_value=True,
+            ):
+                await nats_listener._process_symbol_extraction("BTCUSDT", "15m")
+
+        assert nats_listener._mysql_healthy is True
+        assert nats_listener.signals_emitted == 1
+        assert len(nats_listener._recent_analysis_latencies) == 1

--- a/tests/test_startup_wiring.py
+++ b/tests/test_startup_wiring.py
@@ -5,9 +5,43 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# Ensure petrosa_otel is mocked globally for this test session
-if "petrosa_otel" not in sys.modules:
+_PETROSA_OTEL_PREFIXES = ("petrosa_otel", "ta_bot.evaluators")
+
+
+@pytest.fixture(autouse=True)
+def _mock_petrosa_otel():
+    """Scope the petrosa_otel mock to this module's tests only.
+
+    main() initializes telemetry via petrosa_otel and (per P2.7 #248) wires a
+    health evaluator that imports ``petrosa_otel.evaluators``. These tests mock
+    the whole package so telemetry init is a no-op and the evaluator import
+    fails fast (leaving the evaluator disabled). Previously this stub was
+    installed at module import time and leaked into sys.modules globally,
+    breaking other modules (e.g. tests/unit/test_health_evaluator.py) that need
+    the real framework. Saving/restoring around each test keeps it isolated.
+    """
+    saved = {
+        k: sys.modules[k]
+        for k in list(sys.modules)
+        if k == "petrosa_otel"
+        or k.startswith(tuple(p + "." for p in _PETROSA_OTEL_PREFIXES))
+        or k in _PETROSA_OTEL_PREFIXES
+    }
+    for k in saved:
+        del sys.modules[k]
     sys.modules["petrosa_otel"] = MagicMock()
+    try:
+        yield
+    finally:
+        for k in [
+            m
+            for m in list(sys.modules)
+            if m == "petrosa_otel"
+            or m.startswith(tuple(p + "." for p in _PETROSA_OTEL_PREFIXES))
+            or m in _PETROSA_OTEL_PREFIXES
+        ]:
+            del sys.modules[k]
+        sys.modules.update(saved)
 
 
 def reload_ta_bot_modules():

--- a/tests/unit/test_health_evaluator.py
+++ b/tests/unit/test_health_evaluator.py
@@ -1,5 +1,6 @@
 """Unit tests for BotTaAnalysisHealthEvaluator (#248, P2.7 AC4)."""
 
+import asyncio
 import json
 from datetime import UTC, datetime, timedelta
 
@@ -185,3 +186,66 @@ def test_build_returns_none_without_nats():
         publisher = _Pub()
 
     assert build_bot_ta_analysis_health_evaluator(_Listener()) is None
+
+
+def test_build_returns_evaluator_with_nats():
+    class _Pub:
+        nats_client = FakeNats()
+
+    class _Listener:
+        publisher = _Pub()
+
+        def get_health_metrics(self):
+            return {
+                "nats_connected": True,
+                "mysql_healthy": True,
+                "analysis_latency_s": 0.0,
+                "signals_emitted": 0,
+            }
+
+    ev = build_bot_ta_analysis_health_evaluator(_Listener())
+    assert isinstance(ev, BotTaAnalysisHealthEvaluator)
+
+
+@pytest.mark.asyncio
+async def test_emit_loop_tolerates_source_errors(clock):
+    """The emit loop logs and continues when a tick raises (never crashes)."""
+
+    def _bad_source() -> dict:
+        raise RuntimeError("boom")
+
+    ev = BotTaAnalysisHealthEvaluator(
+        metrics_source=_bad_source,
+        publisher=None,
+        hysteresis=ConsecutiveSamplesHysteresis(n=1),
+        emit_interval_s=0.01,
+        time_source=clock,
+    )
+    await ev.start()
+    await asyncio.sleep(0.03)
+    await ev.stop()  # must not raise despite the failing source
+
+
+@pytest.mark.asyncio
+async def test_start_stop_lifecycle_publishes(clock):
+    """start() runs the emit loop (at least one tick) and stop() cancels it."""
+    src = MetricsSource()
+    nats = FakeNats()
+    publisher = NatsVerdictPublisher(nats_client=nats)
+    ev = BotTaAnalysisHealthEvaluator(
+        metrics_source=src,
+        publisher=publisher,
+        hysteresis=ConsecutiveSamplesHysteresis(n=1),
+        emit_interval_s=0.01,
+        time_source=clock,
+    )
+    await ev.start()
+    await ev.start()  # idempotent — second call is a no-op
+    # Let the loop tick a few times (unknown → healthy).
+    await asyncio.sleep(0.05)
+    await ev.stop()
+    await ev.stop()  # idempotent when already stopped
+
+    assert nats.messages, "emit loop did not publish"
+    subject, _ = nats.messages[-1]
+    assert subject == "evaluator.bot-ta-analysis.verdict"

--- a/tests/unit/test_health_evaluator.py
+++ b/tests/unit/test_health_evaluator.py
@@ -1,0 +1,187 @@
+"""Unit tests for BotTaAnalysisHealthEvaluator (#248, P2.7 AC4)."""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from petrosa_otel.evaluators import ConsecutiveSamplesHysteresis
+from petrosa_otel.evaluators.publisher import (
+    EVALUATOR_SUBJECT_TEMPLATE,
+    NatsVerdictPublisher,
+)
+
+from ta_bot.evaluators import (
+    BotTaAnalysisHealthEvaluator,
+    build_bot_ta_analysis_health_evaluator,
+)
+
+
+class FakeClock:
+    def __init__(self, start: datetime, step: timedelta) -> None:
+        self._t = start
+        self._step = step
+
+    def __call__(self) -> datetime:
+        now = self._t
+        self._t = self._t + self._step
+        return now
+
+
+class MetricsSource:
+    def __init__(self) -> None:
+        self.snap = {
+            "nats_connected": True,
+            "mysql_healthy": True,
+            "analysis_latency_s": 0.5,
+            "signals_emitted": 0,
+        }
+
+    def __call__(self) -> dict:
+        return dict(self.snap)
+
+
+class FakeNats:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, bytes]] = []
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        self.messages.append((subject, payload))
+
+
+def _make(source, clock, *, publisher=None, n: int = 1):
+    return BotTaAnalysisHealthEvaluator(
+        metrics_source=source,
+        publisher=publisher,
+        hysteresis=ConsecutiveSamplesHysteresis(n=n),
+        time_source=clock,
+    )
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock(datetime(2026, 5, 27, 12, 0, 0, tzinfo=UTC), timedelta(seconds=15))
+
+
+@pytest.mark.asyncio
+async def test_first_sample_is_unknown(clock):
+    ev = _make(MetricsSource(), clock)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unknown"
+    assert "baseline" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_connected_and_ok(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()
+    verdict, reason = await ev.evaluate()
+    assert verdict == "healthy"
+    assert "MySQL ok" in reason
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_nats_disconnected(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()
+    src.snap["nats_connected"] = False
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "NATS" in reason
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_mysql_unhealthy(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()
+    src.snap["mysql_healthy"] = False
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "candle-data" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_on_high_latency(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()
+    src.snap["analysis_latency_s"] = 8.0  # > 5s threshold
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "latency" in reason
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_on_signal_collapse(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()  # prime
+    signals = 0
+    for _ in range(4):
+        signals += 1  # ~0.067 signals/s baseline
+        src.snap["signals_emitted"] = signals
+        verdict, _ = await ev.evaluate()
+        assert verdict == "healthy"
+    # Emission stops while everything else stays nominal.
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "signal emission collapsed" in reason
+
+
+@pytest.mark.asyncio
+async def test_counter_reset_returns_unknown(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    src.snap["signals_emitted"] = 500
+    await ev.evaluate()
+    src.snap["signals_emitted"] = 3  # pod restart
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unknown"
+    assert "reset" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_publishes_on_bot_ta_analysis_subject(clock):
+    src = MetricsSource()
+    nats = FakeNats()
+    publisher = NatsVerdictPublisher(nats_client=nats)
+    ev = _make(src, clock, publisher=publisher, n=1)
+
+    await ev.tick()  # unknown baseline
+    await ev.tick()  # healthy
+
+    assert nats.messages, "evaluator did not publish"
+    subject, payload = nats.messages[-1]
+    assert subject == "evaluator.bot-ta-analysis.verdict"
+    assert subject == EVALUATOR_SUBJECT_TEMPLATE.format(subsystem="bot-ta-analysis")
+    body = json.loads(payload.decode())
+    assert body["subsystem"] == "bot-ta-analysis"
+    assert body["verdict"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_hysteresis_suppresses_single_flap(clock):
+    src = MetricsSource()
+    ev = _make(src, clock, n=3)
+
+    await ev.tick()  # unknown baseline
+    for _ in range(3):
+        v = await ev.tick()
+    assert v.verdict == "healthy"
+
+    # One MySQL-down sample must NOT flip the committed verdict (n=3).
+    src.snap["mysql_healthy"] = False
+    v = await ev.tick()
+    assert v.verdict == "healthy"
+
+
+def test_build_returns_none_without_nats():
+    class _Pub:
+        nats_client = None
+
+    class _Listener:
+        publisher = _Pub()
+
+    assert build_bot_ta_analysis_health_evaluator(_Listener()) is None


### PR DESCRIPTION
## Summary

Adopts the shared **P2.1 evaluator framework** (`petrosa_otel.evaluators`) so `petrosa-bot-ta-analysis` publishes a structured health verdict on **`evaluator.bot-ta-analysis.verdict`** — closing one of the five "silent service" gaps that keep **FR17 / FR23 / FR32** at 🟡 YELLOW (parent EPIC [petrosa_k8s#697](https://github.com/PetroSa2/petrosa_k8s/issues/697), AC4).

Implements [#248](https://github.com/PetroSa2/petrosa-bot-ta-analysis/issues/248). Mirrors merged siblings socket-client#123 (PR #124) and realtime-strategies#175 (PR #176).

## What changed

- **`BotTaAnalysisHealthEvaluator`** (`ta_bot/evaluators/health_evaluator.py`) subclasses `petrosa_otel.evaluators.Evaluator` and computes a raw verdict from the three required signals (per #697 AC4):
  - **Indicator-compute latency** — rolling mean of the `analyze_candles` duration; sustained mean > 5s trips it.
  - **MySQL connection health** — whether the most recent candle-data fetch succeeded (the bot reads candles via MySQL / the Data Manager fronting it).
  - **Signal-emission rate** — outbound signal count; collapse below 10% of an established baseline. TA signals are sparse (candle-close driven), so the check stays dormant below a min baseline rate to avoid false trips.
- **`NATSListener` instrumented** (the hub that owns the signal engine, candle client, and publisher) with readable signals — an analysis-latency deque, a `signals_emitted` counter, a `mysql_healthy` flag set from fetch outcomes, and a `get_health_metrics()` accessor. No behavioral change to message handling.
- Publishes via the framework `NatsVerdictPublisher` on `evaluator.bot-ta-analysis.verdict` (the publisher's NATS connection).
- **Hysteresis (AC4 / AC7):** `ConsecutiveSamplesHysteresis(n=3)` over 15s → ~45s decision window (documented).
- **Lifecycle:** started/stopped in `main()` after the listener + publisher are up and verified; guarded so an older `petrosa-otel` degrades gracefully.
- **Dependency:** `petrosa-otel` pin `>=1.0.6` → `>=1.1.0` (first published version shipping the framework).

### Verdict vocabulary note
The framework's `EvaluatorVerdict` enforces the locked three-state contract `healthy | unhealthy | unknown` (no `degraded`). Any breached signal maps to **`unhealthy`** with a single-line reason naming the tripped signal (NFR-O5). Consistent with all shipped producers.

## Acceptance criteria

- [x] **AC1** — `BotTaAnalysisHealthEvaluator(petrosa_otel.evaluators.Evaluator)` exists and is started/stopped in the service lifecycle.
- [x] **AC2** — Publishes `evaluator.bot-ta-analysis.verdict` via the framework publisher with verdict + reason.
- [x] **AC3** — The three health signals feed the raw verdict.
- [x] **AC4** — Hysteresis applied; threshold/window documented.
- [x] **AC5** — Unit tests cover verdict transitions and assert the publish subject.
- [x] **AC6** — CI (ruff / mypy / tests) — validated locally; see test plan.

## Test plan

- [x] `pytest tests/unit/test_health_evaluator.py` — 10 tests: unknown-on-first-sample, healthy path, unhealthy on NATS disconnect / MySQL-down / high latency / signal collapse, counter-reset rebaseline, publish-subject assertion, hysteresis flap suppression, `build_*` returns None without NATS.
- [x] Full suite green; coverage ≥75% gate satisfied.
- [x] `ruff check` clean; `ruff format` clean; bandit `-ll` 0 issues.

Closes #248
