### PR TITLE
feat: 238 - content-addressable strategy revision binding (FR53 / P3.4 AC1+AC2)

### DIFF
--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -19,6 +19,13 @@ from backtest.data_source import (
 )
 from backtest.engine import BacktestEngine
 from backtest.identifiers import make_decision_id
+from backtest.strategy_revision import (
+    StrategyRevision,
+    build_strategy_revision,
+    compute_parameter_set_hash,
+    compute_strategy_module_hash,
+    compute_strategy_revision_id,
+)
 
 __all__ = [
     "BacktestEngine",
@@ -31,5 +38,10 @@ __all__ = [
     "HistoricalDataSource",
     "SensitivityAnalysis",
     "SensitivityPoint",
+    "StrategyRevision",
+    "build_strategy_revision",
+    "compute_parameter_set_hash",
+    "compute_strategy_module_hash",
+    "compute_strategy_revision_id",
     "make_decision_id",
 ]

--- a/backtest/artifact.py
+++ b/backtest/artifact.py
@@ -4,6 +4,10 @@ Schema evolution:
   1.0.0 — per-event signals only (decision_id, action, confidence, price)
   1.1.0 — adds edge_estimate, drawdown_envelope, sensitivity_analysis
            (all three are Optional for backward compat when loading 1.0.0 JSON)
+  1.2.0 — adds strategy_revision_id + strategy_revision (FR53 / P3.4 AC1):
+           content-addressable identity bound to the strategy snapshot used
+           to produce this artifact. Optional on load so legacy artifacts
+           still deserialize.
 """
 
 from __future__ import annotations
@@ -12,6 +16,8 @@ import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
+
+from backtest.strategy_revision import StrategyRevision
 
 
 @dataclass(frozen=True)
@@ -91,6 +97,12 @@ class CharacterizationArtifact:
     edge_estimate: EdgeEstimate | None = None
     drawdown_envelope: DrawdownEnvelope | None = None
     sensitivity_analysis: SensitivityAnalysis | None = None
+    # v1.2.0 strategy-revision binding (FR53 / P3.4 AC1+AC2). Short id is
+    # duplicated at the top level so consumers can refuse-on-mismatch without
+    # walking the nested dict; the full StrategyRevision carries the
+    # component hashes so consumers can attribute drift to code vs params.
+    strategy_revision_id: str | None = None
+    strategy_revision: StrategyRevision | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
@@ -108,7 +120,7 @@ class CharacterizationArtifact:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CharacterizationArtifact:
-        """Deserialise from a dict; handles both v1.0.0 and v1.1.0 shapes."""
+        """Deserialise from a dict; handles v1.0.0, v1.1.0, and v1.2.0 shapes."""
         events = tuple(
             BacktestEvent(**e) if isinstance(e, dict) else e
             for e in data.get("events", [])
@@ -127,6 +139,9 @@ class CharacterizationArtifact:
         else:
             sa = None
 
+        revision_raw = data.get("strategy_revision")
+        revision = StrategyRevision.from_dict(revision_raw) if revision_raw else None
+
         return cls(
             schema_version=data["schema_version"],
             strategy_id=data["strategy_id"],
@@ -141,6 +156,8 @@ class CharacterizationArtifact:
             edge_estimate=edge,
             drawdown_envelope=dd,
             sensitivity_analysis=sa,
+            strategy_revision_id=data.get("strategy_revision_id"),
+            strategy_revision=revision,
         )
 
     @classmethod

--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -22,8 +22,9 @@ from backtest.analytics import (
 from backtest.artifact import BacktestEvent, CharacterizationArtifact
 from backtest.data_source import HistoricalDataSource
 from backtest.identifiers import make_decision_id
+from backtest.strategy_revision import StrategyRevision, build_strategy_revision
 
-ARTIFACT_SCHEMA_VERSION = "1.1.0"
+ARTIFACT_SCHEMA_VERSION = "1.2.0"
 BACKTEST_SOURCE = "backtest"
 
 logger = logging.getLogger(__name__)
@@ -70,6 +71,8 @@ class BacktestEngine:
         if request.warmup < 1:
             raise ValueError("warmup must be >= 1")
 
+        revision = self._resolve_strategy_revision(engine, request.strategy_id)
+
         df = self._data_source.load(
             symbol=request.symbol,
             period=request.period,
@@ -99,6 +102,8 @@ class BacktestEngine:
                 edge_estimate=compute_edge_estimate([]),
                 drawdown_envelope=compute_drawdown_envelope([]),
                 sensitivity_analysis=compute_sensitivity_analysis([]),
+                strategy_revision_id=revision.revision_id,
+                strategy_revision=revision,
             )
 
         sequence = 0
@@ -150,6 +155,27 @@ class BacktestEngine:
             edge_estimate=compute_edge_estimate(events_tuple),
             drawdown_envelope=compute_drawdown_envelope(events_tuple),
             sensitivity_analysis=compute_sensitivity_analysis(events_tuple),
+            strategy_revision_id=revision.revision_id,
+            strategy_revision=revision,
+        )
+
+    @staticmethod
+    def _resolve_strategy_revision(engine, strategy_id: str) -> StrategyRevision:
+        """Bind the artifact to ``(strategy module source, default parameters)``.
+
+        Live overrides flow through ``metadata['config']`` at signal time; the
+        backtest path takes the defaults registry as the parameter snapshot so
+        re-runs over the same window remain byte-identical (FR4) and produce
+        the same revision id.
+        """
+        from ta_bot.strategies.defaults import get_strategy_defaults
+
+        strategy_cls = type(engine.strategies[strategy_id])
+        parameters = get_strategy_defaults(strategy_id)
+        return build_strategy_revision(
+            strategy_id=strategy_id,
+            strategy_cls=strategy_cls,
+            parameters=parameters,
         )
 
 

--- a/backtest/strategy_revision.py
+++ b/backtest/strategy_revision.py
@@ -1,0 +1,177 @@
+"""Content-addressable strategy revision identity (FR53 / P3.4 AC1).
+
+Binds a *characterization artifact* to a stable identifier derived from
+``(strategy_module_source, parameter_set)``. Same source + same parameters
+always produce the same revision id; any mutation of either side produces a
+different id, so a CIO consumer can refuse to apply a stale characterization
+to a strategy whose code or default parameters have drifted.
+
+Determinism rules:
+    * Module hash uses the strategy class's source file (``inspect.getsourcefile``)
+      so the hash is stable against decorators and out-of-class helpers defined
+      in the same file. Falls back to ``inspect.getsource(cls)`` if no file
+      can be located (e.g. classes generated in tests via ``exec``).
+    * Parameter hash uses canonical JSON: ``sort_keys=True``,
+      ``separators=(",", ":")``, with a typed default that normalizes
+      ``Enum``, ``datetime`` (assumed UTC if naive — same rule as the
+      data-manager ``compute_inputs_hash``), and ``Path``.
+    * The combined ``revision_id`` is ``srev_{module[:12]}_{params[:12]}`` —
+      short enough for logs and Grafana labels, with the full 64-hex
+      components available on the :class:`StrategyRevision` dataclass.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+_REVISION_ID_PREFIX = "srev_"
+_HEX_PREFIX_LEN = 12
+
+
+@dataclass(frozen=True)
+class StrategyRevision:
+    """Content-addressable identity for a strategy snapshot.
+
+    Carries both the short combined ``revision_id`` (intended for log/UI
+    use) and the two full-length component hashes so downstream consumers
+    can detect *why* a revision differs (code change vs. parameter change).
+    """
+
+    strategy_id: str
+    revision_id: str
+    module_hash: str
+    parameter_hash: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "strategy_id": self.strategy_id,
+            "revision_id": self.revision_id,
+            "module_hash": self.module_hash,
+            "parameter_hash": self.parameter_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StrategyRevision:
+        return cls(
+            strategy_id=str(data["strategy_id"]),
+            revision_id=str(data["revision_id"]),
+            module_hash=str(data["module_hash"]),
+            parameter_hash=str(data["parameter_hash"]),
+        )
+
+
+def compute_strategy_module_hash(strategy_cls: type) -> str:
+    """SHA-256 hex digest of the strategy class's source.
+
+    Prefers the whole source *file* (so refactors that move helpers out of
+    the class body still register as code change). Falls back to
+    ``inspect.getsource`` when only the class body is available, and finally
+    to the class's ``repr`` if even that fails — every fallback still
+    discriminates between distinct class objects so the hash never collapses.
+    """
+    source_file: str | None = None
+    try:
+        source_file = inspect.getsourcefile(strategy_cls)
+    except TypeError:
+        source_file = None
+    if source_file is None:
+        module_name = getattr(strategy_cls, "__module__", None)
+        if module_name:
+            module = sys.modules.get(module_name)
+            module_file = getattr(module, "__file__", None) if module else None
+            if module_file:
+                source_file = module_file
+    if source_file:
+        source = Path(source_file).read_text(encoding="utf-8")
+    else:
+        try:
+            source = inspect.getsource(strategy_cls)
+        except (OSError, TypeError):
+            # Last-resort discriminator: qualified name + module. Stable
+            # across runs (no memory address) and unique per class object.
+            source = (
+                f"<no-source:{strategy_cls.__module__}.{strategy_cls.__qualname__}>"
+            )
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def _canonicalize(value: Any) -> Any:
+    """JSON-default for values json.dumps cannot serialize directly.
+
+    Matches the data-manager ``compute_inputs_hash`` semantics: naive
+    datetimes are tagged UTC, enums collapse to their value, paths to str.
+    """
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.isoformat()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, (set, frozenset)):
+        return sorted(
+            value, key=lambda x: json.dumps(x, default=_canonicalize, sort_keys=True)
+        )
+    raise TypeError(f"Cannot canonicalize {type(value).__name__} for parameter hash")
+
+
+def compute_parameter_set_hash(parameters: dict[str, Any] | None) -> str:
+    """SHA-256 hex digest of a parameter dict under canonical JSON.
+
+    ``None`` and ``{}`` collapse to the same hash so a strategy with no
+    runtime config matches a strategy whose config dict is empty.
+    """
+    canonical = json.dumps(
+        parameters or {},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_canonicalize,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_strategy_revision_id(
+    strategy_cls: type,
+    parameters: dict[str, Any] | None,
+) -> str:
+    """Short content-addressable id for ``(strategy class, parameters)``.
+
+    Shape: ``srev_{module_hash[:12]}_{parameter_hash[:12]}``.
+    """
+    module_hash = compute_strategy_module_hash(strategy_cls)
+    parameter_hash = compute_parameter_set_hash(parameters)
+    return (
+        f"{_REVISION_ID_PREFIX}{module_hash[:_HEX_PREFIX_LEN]}"
+        f"_{parameter_hash[:_HEX_PREFIX_LEN]}"
+    )
+
+
+def build_strategy_revision(
+    *,
+    strategy_id: str,
+    strategy_cls: type,
+    parameters: dict[str, Any] | None,
+) -> StrategyRevision:
+    """Assemble a full :class:`StrategyRevision` for a strategy snapshot."""
+    module_hash = compute_strategy_module_hash(strategy_cls)
+    parameter_hash = compute_parameter_set_hash(parameters)
+    revision_id = (
+        f"{_REVISION_ID_PREFIX}{module_hash[:_HEX_PREFIX_LEN]}"
+        f"_{parameter_hash[:_HEX_PREFIX_LEN]}"
+    )
+    return StrategyRevision(
+        strategy_id=strategy_id,
+        revision_id=revision_id,
+        module_hash=module_hash,
+        parameter_hash=parameter_hash,
+    )

--- a/docs/BACKTEST.md
+++ b/docs/BACKTEST.md
@@ -120,6 +120,44 @@ The hex suffix is derived deterministically from
 `(strategy_id, symbol, candle_timestamp, sequence)` so a re-run against the
 same window yields a byte-identical artifact — the reproducibility AC.
 
+## Strategy revision binding (FR53 / P3.4)
+
+Every emitted artifact now carries a content-addressable **strategy revision
+id** so a consumer (CIO arbitration in `petrosa-cio`, the FR20 fidelity
+evaluator) can refuse to apply a characterization to a strategy whose code
+or default parameters have drifted since the characterization was produced.
+
+The revision id is short and shaped `srev_{module_hash[:12]}_{parameter_hash[:12]}`
+— compact enough for log lines and Grafana labels. The full 64-hex
+component hashes are also stored on the nested `strategy_revision`
+object so a consumer can attribute drift to a code change vs. a parameter
+change without re-running the backtest:
+
+```json
+"strategy_revision_id": "srev_5d92f1c0a8e2_d3b71f3c2e3a",
+"strategy_revision": {
+  "strategy_id": "ema_alignment_bullish",
+  "revision_id": "srev_5d92f1c0a8e2_d3b71f3c2e3a",
+  "module_hash": "5d92f1c0a8e2…",
+  "parameter_hash": "d3b71f3c2e3a…"
+}
+```
+
+Determinism:
+
+* `module_hash` is SHA-256 of the strategy class's source *file* (so refactors
+  that move helpers out of the class body still register as a code change).
+* `parameter_hash` is SHA-256 over canonical JSON of the resolved default
+  parameter set (`ta_bot.strategies.defaults.get_strategy_defaults`).
+  Key-order, naive vs. UTC-aware datetimes, and `Enum`/`Path` values all
+  canonicalize the same way as `petrosa-data-manager`'s `compute_inputs_hash`,
+  so the two hashes are interchangeable across the boundary.
+* Empty / missing parameters collapse to the same hash as `{}`.
+
+The CIO consumer side (refusal logic, `rejection_source="stale_characterization"`)
+and the FR20 evaluator binding are tracked separately — they live in
+`petrosa-cio`, not this service.
+
 ## Reproducibility
 
 The engine guarantees that two runs with the same `(strategy_id, symbol,

--- a/tests/backtest/test_artifact.py
+++ b/tests/backtest/test_artifact.py
@@ -14,6 +14,7 @@ from backtest.artifact import (
     SensitivityAnalysis,
     SensitivityPoint,
 )
+from backtest.strategy_revision import StrategyRevision
 
 
 def _v1_artifact() -> CharacterizationArtifact:
@@ -152,3 +153,74 @@ def test_write_json_creates_parent_dir(tmp_path) -> None:
     assert out.exists()
     on_disk = json.loads(out.read_text())
     assert on_disk["strategy_id"] == "momentum_pulse"
+
+
+def _v3_artifact_with_revision() -> CharacterizationArtifact:
+    return CharacterizationArtifact(
+        schema_version="1.2.0",
+        strategy_id="momentum_pulse",
+        symbol="BTCUSDT",
+        period="15m",
+        range_from="2026-01-01T00:00:00+00:00",
+        range_to="2026-01-05T00:00:00+00:00",
+        candle_count=4,
+        signal_count=1,
+        source="backtest",
+        events=(
+            BacktestEvent(
+                decision_id="dec_20260101T000000000_abc123",
+                candle_timestamp="2026-01-01T00:00:00+00:00",
+                action="buy",
+                confidence=0.74,
+                current_price=50000.0,
+                metadata={},
+            ),
+        ),
+        edge_estimate=EdgeEstimate(
+            expected_pnl=0.02, win_rate=1.0, sharpe_ratio=0.0, trade_count=1
+        ),
+        drawdown_envelope=DrawdownEnvelope(p50=0.0, p90=0.0, p99=0.0, p100=0.0),
+        sensitivity_analysis=SensitivityAnalysis(
+            parameter="confidence_threshold",
+            points=(
+                SensitivityPoint(
+                    confidence_threshold=0.0,
+                    win_rate=1.0,
+                    expected_pnl=0.02,
+                    trade_count=1,
+                ),
+            ),
+        ),
+        strategy_revision_id="srev_abc123abc123_def456def456",
+        strategy_revision=StrategyRevision(
+            strategy_id="momentum_pulse",
+            revision_id="srev_abc123abc123_def456def456",
+            module_hash="abc123abc123" + "0" * 52,
+            parameter_hash="def456def456" + "0" * 52,
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_v3_to_json_contains_revision_fields() -> None:
+    artifact = _v3_artifact_with_revision()
+    parsed = json.loads(artifact.to_json())
+    assert parsed["schema_version"] == "1.2.0"
+    assert parsed["strategy_revision_id"] == "srev_abc123abc123_def456def456"
+    assert parsed["strategy_revision"]["module_hash"].startswith("abc123abc123")
+    assert parsed["strategy_revision"]["parameter_hash"].startswith("def456def456")
+
+
+@pytest.mark.unit
+def test_v3_from_json_roundtrip() -> None:
+    artifact = _v3_artifact_with_revision()
+    restored = CharacterizationArtifact.from_json(artifact.to_json())
+    assert restored == artifact
+
+
+@pytest.mark.unit
+def test_legacy_v1_load_leaves_revision_none() -> None:
+    artifact = _v1_artifact()
+    restored = CharacterizationArtifact.from_dict(json.loads(artifact.to_json()))
+    assert restored.strategy_revision_id is None
+    assert restored.strategy_revision is None

--- a/tests/backtest/test_engine_e2e.py
+++ b/tests/backtest/test_engine_e2e.py
@@ -22,6 +22,7 @@ from backtest.artifact import (
 )
 from backtest.data_source import FixtureHistoricalSource
 from backtest.engine import ARTIFACT_SCHEMA_VERSION, BacktestEngine, BacktestRequest
+from backtest.strategy_revision import StrategyRevision
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "candles_BTCUSDT_15m_recorded.json"
 
@@ -60,8 +61,8 @@ def test_backtest_emits_artifact_from_recorded_fixture() -> None:
         assert event.action in {"buy", "sell", "hold", "close"}
         assert 0.0 <= event.confidence <= 1.0
 
-    # v1.1.0 analytic fields must be present and structurally valid (AC1–AC3, AC4)
-    assert artifact.schema_version == ARTIFACT_SCHEMA_VERSION == "1.1.0"
+    # v1.2.0 analytic fields must be present and structurally valid (AC1–AC3, AC4)
+    assert artifact.schema_version == ARTIFACT_SCHEMA_VERSION == "1.2.0"
     assert isinstance(artifact.edge_estimate, EdgeEstimate)
     assert isinstance(artifact.drawdown_envelope, DrawdownEnvelope)
     assert isinstance(artifact.sensitivity_analysis, SensitivityAnalysis)
@@ -71,6 +72,15 @@ def test_backtest_emits_artifact_from_recorded_fixture() -> None:
     assert artifact.drawdown_envelope.p90 <= artifact.drawdown_envelope.p100
     assert artifact.sensitivity_analysis.parameter == "confidence_threshold"
     assert len(artifact.sensitivity_analysis.points) == 5
+
+    # FR53 strategy-revision binding (P3.4 AC1/AC2): every emitted artifact
+    # carries the content-addressable revision of the producing strategy.
+    assert isinstance(artifact.strategy_revision, StrategyRevision)
+    assert artifact.strategy_revision_id == artifact.strategy_revision.revision_id
+    assert artifact.strategy_revision_id.startswith("srev_")
+    assert artifact.strategy_revision.strategy_id == "ema_alignment_bullish"
+    assert len(artifact.strategy_revision.module_hash) == 64
+    assert len(artifact.strategy_revision.parameter_hash) == 64
 
 
 @pytest.mark.e2e
@@ -118,3 +128,7 @@ def test_backtest_handles_short_window() -> None:
     assert artifact.edge_estimate.trade_count == 0
     assert artifact.drawdown_envelope is not None
     assert artifact.sensitivity_analysis is not None
+    # And the strategy revision (FR53) — short-window artifacts still bind
+    # to the producing strategy so consumers can refuse them on drift.
+    assert artifact.strategy_revision is not None
+    assert artifact.strategy_revision_id.startswith("srev_")

--- a/tests/backtest/test_strategy_revision.py
+++ b/tests/backtest/test_strategy_revision.py
@@ -1,0 +1,179 @@
+"""Determinism + drift-sensitivity tests for the content-addressable strategy
+revision (FR53 / P3.4 AC1).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+
+import pytest
+
+from backtest.strategy_revision import (
+    StrategyRevision,
+    build_strategy_revision,
+    compute_parameter_set_hash,
+    compute_strategy_module_hash,
+    compute_strategy_revision_id,
+)
+
+
+class _AlphaStrategy:
+    """Stand-in strategy class A."""
+
+    name = "alpha"
+
+
+class _BetaStrategy:
+    """Stand-in strategy class B (different source file would normally diverge;
+    these two share a file so the test focuses on parameter-side drift)."""
+
+    name = "beta"
+
+
+@pytest.mark.unit
+def test_revision_id_is_deterministic_same_inputs() -> None:
+    a = compute_strategy_revision_id(_AlphaStrategy, {"rsi_period": 14})
+    b = compute_strategy_revision_id(_AlphaStrategy, {"rsi_period": 14})
+    assert a == b
+
+
+@pytest.mark.unit
+def test_revision_id_has_expected_shape() -> None:
+    rid = compute_strategy_revision_id(_AlphaStrategy, {})
+    assert rid.startswith("srev_")
+    parts = rid.split("_")
+    assert len(parts) == 3  # ['srev', module12, params12]
+    assert len(parts[1]) == 12
+    assert len(parts[2]) == 12
+    assert all(c in "0123456789abcdef" for c in parts[1])
+    assert all(c in "0123456789abcdef" for c in parts[2])
+
+
+@pytest.mark.unit
+def test_parameter_hash_invariant_to_key_order() -> None:
+    h1 = compute_parameter_set_hash({"a": 1, "b": 2})
+    h2 = compute_parameter_set_hash({"b": 2, "a": 1})
+    assert h1 == h2
+
+
+@pytest.mark.unit
+def test_parameter_hash_treats_none_and_empty_equivalently() -> None:
+    assert compute_parameter_set_hash(None) == compute_parameter_set_hash({})
+
+
+@pytest.mark.unit
+def test_parameter_hash_changes_with_value() -> None:
+    h1 = compute_parameter_set_hash({"rsi_period": 14})
+    h2 = compute_parameter_set_hash({"rsi_period": 21})
+    assert h1 != h2
+
+
+@pytest.mark.unit
+def test_parameter_hash_changes_with_added_key() -> None:
+    h1 = compute_parameter_set_hash({"rsi_period": 14})
+    h2 = compute_parameter_set_hash({"rsi_period": 14, "extra": True})
+    assert h1 != h2
+
+
+@pytest.mark.unit
+def test_parameter_hash_canonicalizes_datetime() -> None:
+    naive = datetime(2026, 1, 1, 12, 0, 0)
+    aware_utc = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    # Naive treated as UTC — matches data-manager compute_inputs_hash rule.
+    assert compute_parameter_set_hash({"t": naive}) == compute_parameter_set_hash(
+        {"t": aware_utc}
+    )
+
+
+@pytest.mark.unit
+def test_parameter_hash_canonicalizes_enum_and_path() -> None:
+    class Mode(Enum):
+        A = "alpha"
+
+    h_enum = compute_parameter_set_hash({"mode": Mode.A})
+    h_str = compute_parameter_set_hash({"mode": "alpha"})
+    assert h_enum == h_str
+
+    h_path = compute_parameter_set_hash({"out": Path("/tmp/x")})
+    h_pstr = compute_parameter_set_hash({"out": "/tmp/x"})
+    assert h_path == h_pstr
+
+
+@pytest.mark.unit
+def test_parameter_hash_rejects_uncanonicalizable() -> None:
+    class Unserializable:
+        pass
+
+    with pytest.raises(TypeError, match="Cannot canonicalize") as exc_info:
+        compute_parameter_set_hash({"weird": Unserializable()})
+    assert "Unserializable" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_module_hash_changes_with_source_drift(tmp_path, monkeypatch) -> None:
+    """Two classes loaded from different source files produce different
+    module hashes — emulating a real code change between characterizations.
+    """
+    # Write two near-identical source files differing by one constant.
+    src_a = tmp_path / "strat_a.py"
+    src_a.write_text(
+        "class Strat:\n    name = 'a'\n    threshold = 0.1\n",
+        encoding="utf-8",
+    )
+    src_b = tmp_path / "strat_b.py"
+    src_b.write_text(
+        "class Strat:\n    name = 'a'\n    threshold = 0.2\n",
+        encoding="utf-8",
+    )
+    import importlib.util
+    import sys
+
+    def _load(path: Path, mod_name: str):
+        spec = importlib.util.spec_from_file_location(mod_name, path)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        # Register so inspect.getsourcefile / sys.modules lookups succeed.
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+        return mod.Strat
+
+    cls_a = _load(src_a, "strat_a_test")
+    cls_b = _load(src_b, "strat_b_test")
+    try:
+        assert compute_strategy_module_hash(cls_a) != compute_strategy_module_hash(
+            cls_b
+        )
+    finally:
+        sys.modules.pop("strat_a_test", None)
+        sys.modules.pop("strat_b_test", None)
+
+
+@pytest.mark.unit
+def test_build_strategy_revision_round_trip() -> None:
+    rev = build_strategy_revision(
+        strategy_id="alpha",
+        strategy_cls=_AlphaStrategy,
+        parameters={"x": 1},
+    )
+    assert isinstance(rev, StrategyRevision)
+    assert rev.strategy_id == "alpha"
+    assert rev.revision_id.startswith("srev_")
+    assert len(rev.module_hash) == 64
+    assert len(rev.parameter_hash) == 64
+
+    as_dict = rev.to_dict()
+    restored = StrategyRevision.from_dict(as_dict)
+    assert restored == rev
+
+
+@pytest.mark.unit
+def test_distinct_strategies_yield_distinct_module_hashes() -> None:
+    # Use real strategy classes — different source files guarantee divergence.
+    from ta_bot.strategies.momentum_pulse import MomentumPulseStrategy
+    from ta_bot.strategies.rsi_extreme_reversal import RSIExtremeReversalStrategy
+
+    h1 = compute_strategy_module_hash(MomentumPulseStrategy)
+    h2 = compute_strategy_module_hash(RSIExtremeReversalStrategy)
+    assert h1 != h2


### PR DESCRIPTION
## Summary

Implements **AC1 + producer-side AC2** of [PetroSa2/petrosa-bot-ta-analysis#238](https://github.com/PetroSa2/petrosa-bot-ta-analysis/issues/238) (FR53 / P3.4): content-addressable strategy revision binding for characterization artifacts.

Every artifact the backtest engine emits now carries a stable `strategy_revision_id` derived from:
1. SHA-256 of the strategy's source file (module-level — so refactors that move helpers out of the class body still register as code change).
2. SHA-256 of the strategy's resolved default-parameter set under canonical JSON.

Result shape (`srev_5d92f1c0a8e2_d3b71f3c2e3a`) is short enough for log lines and Grafana labels; the nested `strategy_revision` object also carries the full 64-hex component hashes so a consumer can attribute drift to code vs. parameters without re-running the backtest.

## What's in this PR

- **`backtest/strategy_revision.py`** (new) — `compute_strategy_module_hash`, `compute_parameter_set_hash`, `compute_strategy_revision_id`, `build_strategy_revision`, and the `StrategyRevision` dataclass. Canonicalization mirrors data-manager's `compute_inputs_hash`: naive datetimes → UTC, `Enum` → value, `Path` → str. Module hash falls back gracefully when source isn't on disk (dynamically-loaded classes in tests).
- **`backtest/artifact.py`** — schema bumped 1.1.0 → 1.2.0. New `strategy_revision_id` (top-level short id) and `strategy_revision` (component hashes). Legacy v1.0.0 / v1.1.0 artifacts still deserialize — the new fields default to `None`.
- **`backtest/engine.py`** — engine resolves the strategy class + defaults registry at run time and embeds the revision in every emitted artifact (including the empty short-window path).
- **Tests:** 12 new tests in `tests/backtest/test_strategy_revision.py` (determinism, parameter sensitivity, datetime/enum/path canonicalization, module-source drift, real-strategy divergence) + extended `test_artifact.py` for v1.2.0 round-trip + extended `test_engine_e2e.py` to assert the revision is populated.
- **`docs/BACKTEST.md`** — new "Strategy revision binding (FR53 / P3.4)" section.

Full local test suite: **678 passed, 5 skipped**.

## Scope decision (single-pass, multi-repo ticket)

#238's 6 ACs span 3 repos. This PR lands the producer-side work (AC1 + AC2 producer side) that lives in `petrosa-bot-ta-analysis`. The remaining work is **filed as cross-repo follow-ups** so this PR is reviewable in one pass:

- **AC3** (`petrosa-cio` refusal logic, `rejection_source="stale_characterization"`) → follow-up issue in `petrosa-cio`.
- **AC5** (FR20 strategy-fidelity evaluator binding) → follow-up; needs FR20 location confirmed first.
- **AC2** typed field on `petrosa-data-manager`'s `Characterization` Pydantic model — the artifact dict already carries `strategy_revision_id` via the existing generic `/insert` endpoint and is queryable today, but adding a typed field (with `verify_characterization`'s strict byte-equality contract) is a separate data-manager PR.
- **AC4** operational re-characterization workflow.
- **AC6** cross-repo integration test driving the full loop.

These will be filed before merge so the #238 parent carries a clear partial-complete signal.

## Test plan

- [x] `pytest tests/backtest/` — 55 passed
- [x] `pytest tests/` — 678 passed, 5 skipped
- [x] `ruff check backtest/ tests/backtest/` — clean
- [x] `mypy backtest/strategy_revision.py backtest/artifact.py backtest/engine.py` — 0 errors in touched files (pre-existing errors in other files unchanged)
- [x] Pre-commit hooks (ruff-format, gitleaks, bandit, test-assertions check) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
