### PR TITLE
feat: add recommended_leverage to Signal contract (#251, P1.5-AC1)

### DIFF
--- a/ta_bot/models/signal.py
+++ b/ta_bot/models/signal.py
@@ -146,6 +146,20 @@ class Signal(BaseModel):
     take_profit_pct: float | None = Field(None, ge=0, le=1)
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
+    # FR52 / P1.5-AC1 (#251) — content-addressable max-leverage opinion
+    # carried from the producer to CIO. `None` (not 0) means "no
+    # recommendation — CIO picks from strategy/portfolio defaults".
+    # `ge=1` rejects 0 explicitly as a sentinel. CIO arbitration logic
+    # against portfolio aggregates ships in a separate child story.
+    recommended_leverage: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Max leverage multiplier the producer's characterization supports. "
+            "None = no recommendation."
+        ),
+    )
+
     # Traceability: intent_id generated per signal, carried through to CIO
     intent_id: str = Field(
         default_factory=lambda: uuid.uuid4().hex,

--- a/tests/unit/test_recommended_leverage_field.py
+++ b/tests/unit/test_recommended_leverage_field.py
@@ -1,0 +1,67 @@
+"""FR52 / P1.5-AC1 (#251) — Signal.recommended_leverage producer field.
+
+Parallel to petrosa-realtime-strategies#177. Adds the optional
+`recommended_leverage: int | None` field to the bot-ta-analysis Signal
+contract so strategies whose characterization yields a max-leverage envelope
+can carry the opinion to CIO. `None` (not 0) means "no recommendation".
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ta_bot.models.signal import Signal
+
+
+def _base_signal_kwargs() -> dict:
+    """The minimum required fields to construct a Signal."""
+    return {
+        "strategy_id": "test_strategy_15m",
+        "symbol": "BTCUSDT",
+        "action": "buy",
+        "confidence": 0.75,
+        "current_price": 50000.0,
+        "price": 50000.0,
+    }
+
+
+def test_signal_defaults_recommended_leverage_to_none():
+    """Producers that don't set the field keep working (AC1.c — backwards-
+    compatible default)."""
+    signal = Signal(**_base_signal_kwargs())
+    assert signal.recommended_leverage is None
+
+
+def test_signal_accepts_recommended_leverage():
+    signal = Signal(**_base_signal_kwargs(), recommended_leverage=5)
+    assert signal.recommended_leverage == 5
+
+
+def test_signal_round_trips_recommended_leverage_through_dump_load():
+    """AC1.d — model_dump → Signal(**dumped) preserves the field."""
+    original = Signal(**_base_signal_kwargs(), recommended_leverage=3)
+    rebuilt = Signal(**original.model_dump())
+    assert rebuilt.recommended_leverage == 3
+
+
+def test_signal_rejects_recommended_leverage_below_one():
+    """`ge=1` — 0 is not a valid 'no recommendation' sentinel; callers must
+    use None for that semantics."""
+    with pytest.raises(ValidationError) as exc_info:
+        Signal(**_base_signal_kwargs(), recommended_leverage=0)
+    assert "recommended_leverage" in str(exc_info.value)
+
+
+def test_signal_to_dict_carries_recommended_leverage():
+    """`to_dict()` round-trips the field for downstream JSON consumers."""
+    signal = Signal(**_base_signal_kwargs(), recommended_leverage=2)
+    data = signal.to_dict()
+    assert data["recommended_leverage"] == 2
+
+
+def test_signal_to_dict_defaults_recommended_leverage_to_none():
+    """A signal with no leverage opinion serializes the field as None."""
+    signal = Signal(**_base_signal_kwargs())
+    data = signal.to_dict()
+    assert data["recommended_leverage"] is None


### PR DESCRIPTION
Closes #251. Parallel producer change to realtime-strategies#177/#178. Adds optional `recommended_leverage: int | None = None` (ge=1) to bot-ta-analysis' Signal contract.

## Test plan
- [x] 6 new tests pass: default-None, accepts non-None, dump/load, rejects 0, to_dict() carries value + None.
- [x] ruff check + ruff format clean.

Closes #251