### PR TITLE
feat: 252 - CharacterizationArtifact v1.3.0 max_leverage_envelope (P1.5-AC2)

### DIFF
--- a/backtest/analytics.py
+++ b/backtest/analytics.py
@@ -35,6 +35,14 @@ from backtest.artifact import (
 
 _SENSITIVITY_THRESHOLDS = (0.0, 0.30, 0.50, 0.70, 0.90)
 
+# P1.5-AC2 (#252) — defaults for the max-leverage envelope helper. The operator
+# can override these per-strategy in the persistence path; the values here are
+# the conservative producer-side fallbacks used when the artifact is generated
+# without an explicit operator budget. Operator-configurable bounds + versioning
+# is petrosa-data-manager#182 (separate child story under EPIC #691).
+DEFAULT_OPERATOR_DRAWDOWN_BUDGET = 0.10  # 10% drawdown budget — safe default
+DEFAULT_OPERATOR_MAX_LEVERAGE = 10.0  # P1.5 absolute cap on producer recommendation
+
 
 def _pair_trades(events: Sequence[BacktestEvent]) -> list[float]:
     """Return per-trade returns (fraction) for consecutive buy→sell/close pairs."""
@@ -137,3 +145,53 @@ def compute_sensitivity_analysis(
     """Sweep confidence thresholds and report how edge changes."""
     points = tuple(_edge_at_threshold(events, t) for t in thresholds)
     return SensitivityAnalysis(parameter="confidence_threshold", points=points)
+
+
+def compute_max_leverage_envelope(
+    events: Sequence[BacktestEvent],
+    drawdown_envelope: DrawdownEnvelope,
+    budget: float = DEFAULT_OPERATOR_DRAWDOWN_BUDGET,
+    operator_max: float = DEFAULT_OPERATOR_MAX_LEVERAGE,
+) -> float:
+    """P1.5-AC2 (#252) — analytic upper bound on leverage from the drawdown envelope.
+
+    Derives the max leverage at which the strategy's characterized 99th-percentile
+    drawdown stays inside the operator's drawdown budget::
+
+        leverage_bound = budget / drawdown_envelope.p99
+
+    The returned value is clipped to ``operator_max`` so a near-zero drawdown
+    cannot recommend unbounded leverage. ``events`` is accepted to keep the
+    helper's signature symmetric with ``compute_edge_estimate`` /
+    ``compute_drawdown_envelope`` (the parent EPIC's per-artifact callback
+    convention) and is reserved for future per-event refinements; the current
+    formula reads only the already-characterized ``drawdown_envelope``.
+
+    Properties (locked by unit tests in tests/backtest/test_analytics.py):
+      - Monotone in budget: more budget → more leverage (until the cap).
+      - Inverse-monotone in p99 drawdown: more drawdown → less leverage.
+      - Zero-drawdown floor: when ``drawdown_envelope.p99 <= 0`` the bound is
+        ``operator_max`` (cannot divide by zero, and a flat equity curve is a
+        characterization artifact of a strategy with no realised trades, not
+        a license for infinite leverage).
+      - Returns 0.0 when ``budget <= 0`` (operator has forbidden any drawdown).
+
+    Inputs must be non-negative: a negative ``budget`` or ``operator_max`` is
+    clipped to zero before the formula runs. The output is always
+    ``0.0 <= result <= operator_max``.
+    """
+    # ``events`` is intentionally unused on the current code path — the
+    # signature accepts it for forward-compat with per-event refinements
+    # (e.g. tail-conditioning on the equity-curve shape) the EPIC may pull in
+    # later without churning the public API.
+    _ = events
+
+    safe_budget = max(0.0, float(budget))
+    safe_cap = max(0.0, float(operator_max))
+    if safe_budget == 0.0:
+        return 0.0
+    p99 = float(drawdown_envelope.p99)
+    if p99 <= 0.0:
+        return safe_cap
+    bound = safe_budget / p99
+    return min(safe_cap, bound)

--- a/backtest/artifact.py
+++ b/backtest/artifact.py
@@ -8,6 +8,10 @@ Schema evolution:
            content-addressable identity bound to the strategy snapshot used
            to produce this artifact. Optional on load so legacy artifacts
            still deserialize.
+  1.3.0 — adds max_leverage_envelope (FR3 + FR52 / P1.5-AC2 / #252): analytic
+           upper bound on intent leverage derived from drawdown_envelope.p99
+           and the operator's drawdown budget. Optional on load so v1.0–v1.2
+           artifacts still deserialize with ``max_leverage_envelope=None``.
 """
 
 from __future__ import annotations
@@ -103,6 +107,12 @@ class CharacterizationArtifact:
     # component hashes so consumers can attribute drift to code vs params.
     strategy_revision_id: str | None = None
     strategy_revision: StrategyRevision | None = None
+    # v1.3.0 producer-side max-leverage opinion (FR3 + FR52 / P1.5-AC2, #252).
+    # Bounds the leverage CIO is allowed to admit for intents tagged with this
+    # artifact's `strategy_revision_id`. ``None`` on legacy v1.0–v1.2 artifacts
+    # so the field stays optional on load; producers (engine.py) compute it
+    # at characterization time from `drawdown_envelope.p99` + operator budget.
+    max_leverage_envelope: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
@@ -142,6 +152,13 @@ class CharacterizationArtifact:
         revision_raw = data.get("strategy_revision")
         revision = StrategyRevision.from_dict(revision_raw) if revision_raw else None
 
+        # v1.3.0: max_leverage_envelope is optional on load — older artifacts
+        # surface it as ``None`` and producers (engine.py) compute it for new
+        # artifacts. Coerce to float when present so JSON ints round-trip
+        # without surprising consumers that compare against floats.
+        mle_raw = data.get("max_leverage_envelope")
+        mle: float | None = float(mle_raw) if mle_raw is not None else None
+
         return cls(
             schema_version=data["schema_version"],
             strategy_id=data["strategy_id"],
@@ -158,6 +175,7 @@ class CharacterizationArtifact:
             sensitivity_analysis=sa,
             strategy_revision_id=data.get("strategy_revision_id"),
             strategy_revision=revision,
+            max_leverage_envelope=mle,
         )
 
     @classmethod

--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -17,6 +17,7 @@ import pandas as pd
 from backtest.analytics import (
     compute_drawdown_envelope,
     compute_edge_estimate,
+    compute_max_leverage_envelope,
     compute_sensitivity_analysis,
 )
 from backtest.artifact import BacktestEvent, CharacterizationArtifact
@@ -24,7 +25,7 @@ from backtest.data_source import HistoricalDataSource
 from backtest.identifiers import make_decision_id
 from backtest.strategy_revision import StrategyRevision, build_strategy_revision
 
-ARTIFACT_SCHEMA_VERSION = "1.2.0"
+ARTIFACT_SCHEMA_VERSION = "1.3.0"
 BACKTEST_SOURCE = "backtest"
 
 logger = logging.getLogger(__name__)
@@ -88,6 +89,7 @@ class BacktestEngine:
                 candle_count,
                 request.warmup,
             )
+            empty_dd = compute_drawdown_envelope([])
             return CharacterizationArtifact(
                 schema_version=ARTIFACT_SCHEMA_VERSION,
                 strategy_id=request.strategy_id,
@@ -100,10 +102,16 @@ class BacktestEngine:
                 source=BACKTEST_SOURCE,
                 events=(),
                 edge_estimate=compute_edge_estimate([]),
-                drawdown_envelope=compute_drawdown_envelope([]),
+                drawdown_envelope=empty_dd,
                 sensitivity_analysis=compute_sensitivity_analysis([]),
                 strategy_revision_id=revision.revision_id,
                 strategy_revision=revision,
+                # P1.5-AC2.c (#252): producer-side max-leverage envelope. The
+                # under-warmup branch has no trades → drawdown_envelope.p99 == 0
+                # → helper returns operator_max so the artifact still carries a
+                # bounded recommendation rather than ``None`` (the absence path
+                # is reserved for legacy v1.0–v1.2 artifacts loaded from disk).
+                max_leverage_envelope=compute_max_leverage_envelope([], empty_dd),
             )
 
         sequence = 0
@@ -141,6 +149,7 @@ class BacktestEngine:
                 sequence += 1
 
         events_tuple = tuple(events)
+        drawdown_envelope = compute_drawdown_envelope(events_tuple)
         return CharacterizationArtifact(
             schema_version=ARTIFACT_SCHEMA_VERSION,
             strategy_id=request.strategy_id,
@@ -153,10 +162,16 @@ class BacktestEngine:
             source=BACKTEST_SOURCE,
             events=events_tuple,
             edge_estimate=compute_edge_estimate(events_tuple),
-            drawdown_envelope=compute_drawdown_envelope(events_tuple),
+            drawdown_envelope=drawdown_envelope,
             sensitivity_analysis=compute_sensitivity_analysis(events_tuple),
             strategy_revision_id=revision.revision_id,
             strategy_revision=revision,
+            # P1.5-AC2.c (#252): computed once per artifact, persisted via
+            # ArtifactPersister together with drawdown_envelope. Producer's
+            # opinion only — CIO arbitration ships in petrosa-cio#137.
+            max_leverage_envelope=compute_max_leverage_envelope(
+                events_tuple, drawdown_envelope
+            ),
         )
 
     @staticmethod

--- a/tests/backtest/test_analytics.py
+++ b/tests/backtest/test_analytics.py
@@ -9,7 +9,7 @@ from backtest.analytics import (
     compute_edge_estimate,
     compute_sensitivity_analysis,
 )
-from backtest.artifact import BacktestEvent
+from backtest.artifact import BacktestEvent, DrawdownEnvelope
 
 
 def _event(
@@ -163,3 +163,102 @@ def test_sensitivity_analysis_filters_by_threshold() -> None:
     # At threshold 0.5 — buy (0.4) is filtered out → no paired trade
     pt_50 = next(p for p in sa.points if p.confidence_threshold == 0.50)
     assert pt_50.trade_count == 0
+
+
+# ---------------------------------------------------------------------------
+# max_leverage_envelope (P1.5-AC2 / #252)
+# ---------------------------------------------------------------------------
+
+
+def _dd(p99: float, *, p50: float | None = None, p100: float | None = None):
+    """Helper: build a DrawdownEnvelope where only p99 carries semantic weight.
+
+    The other percentiles are filled with consistent placeholders so the
+    dataclass invariants (p50 <= p90 <= p99 <= p100) hold; the helper under
+    test only reads p99.
+    """
+    return DrawdownEnvelope(
+        p50=p50 if p50 is not None else p99,
+        p90=p99,
+        p99=p99,
+        p100=p100 if p100 is not None else p99,
+    )
+
+
+@pytest.mark.unit
+def test_max_leverage_envelope_zero_drawdown_caps_at_operator_max() -> None:
+    """AC2 corner case — flat equity curve → producer cannot recommend more
+    than the operator's hard cap (no implicit infinity from divide-by-zero)."""
+    from backtest.analytics import (
+        DEFAULT_OPERATOR_MAX_LEVERAGE,
+        compute_max_leverage_envelope,
+    )
+
+    bound = compute_max_leverage_envelope([], _dd(0.0))
+    assert bound == DEFAULT_OPERATOR_MAX_LEVERAGE
+
+
+@pytest.mark.unit
+def test_max_leverage_envelope_monotone_in_budget() -> None:
+    """AC2 monotonicity — more budget → more leverage (until the operator cap)."""
+    from backtest.analytics import compute_max_leverage_envelope
+
+    dd = _dd(0.02)  # 2% p99 drawdown
+    low = compute_max_leverage_envelope([], dd, budget=0.05)
+    high = compute_max_leverage_envelope([], dd, budget=0.10)
+    assert high >= low
+    # Increasing budget should strictly increase leverage until the cap.
+    assert high > low
+
+
+@pytest.mark.unit
+def test_max_leverage_envelope_inverse_monotone_in_drawdown() -> None:
+    """AC2 monotonicity — more drawdown → less leverage."""
+    from backtest.analytics import compute_max_leverage_envelope
+
+    low_dd = compute_max_leverage_envelope([], _dd(0.01), budget=0.10)
+    high_dd = compute_max_leverage_envelope([], _dd(0.05), budget=0.10)
+    assert low_dd > high_dd
+
+
+@pytest.mark.unit
+def test_max_leverage_envelope_clipped_at_operator_cap() -> None:
+    """AC2 cap — even when budget/p99 would exceed the cap, output stays bounded."""
+    from backtest.analytics import compute_max_leverage_envelope
+
+    # budget 1.0 / p99 0.01 = 100 → cap at 10.0
+    bound = compute_max_leverage_envelope([], _dd(0.01), budget=1.0, operator_max=10.0)
+    assert bound == 10.0
+
+
+@pytest.mark.unit
+def test_max_leverage_envelope_zero_budget_returns_zero() -> None:
+    """AC2 invariant — operator can pin the producer to no leverage via budget=0."""
+    from backtest.analytics import compute_max_leverage_envelope
+
+    assert compute_max_leverage_envelope([], _dd(0.05), budget=0.0) == 0.0
+
+
+@pytest.mark.unit
+def test_max_leverage_envelope_negative_inputs_clipped_to_safe() -> None:
+    """AC2 defensive — operator misconfig with negatives must not produce
+    negative leverage or a divide-by-bogus value."""
+    from backtest.analytics import compute_max_leverage_envelope
+
+    # Negative budget → treated as 0 → bound = 0
+    assert compute_max_leverage_envelope([], _dd(0.05), budget=-0.1) == 0.0
+    # Negative operator_max → treated as 0 → bound = 0 (cap)
+    assert (
+        compute_max_leverage_envelope([], _dd(0.05), budget=0.1, operator_max=-1.0)
+        == 0.0
+    )
+
+
+@pytest.mark.unit
+def test_max_leverage_envelope_exact_formula_at_simple_inputs() -> None:
+    """AC2 formula — when below the operator cap, bound == budget/p99 exactly."""
+    from backtest.analytics import compute_max_leverage_envelope
+
+    # 0.10 / 0.02 = 5.0 (below the 10.0 cap)
+    bound = compute_max_leverage_envelope([], _dd(0.02), budget=0.10, operator_max=10.0)
+    assert abs(bound - 5.0) < 1e-9

--- a/tests/backtest/test_artifact.py
+++ b/tests/backtest/test_artifact.py
@@ -224,3 +224,106 @@ def test_legacy_v1_load_leaves_revision_none() -> None:
     restored = CharacterizationArtifact.from_dict(json.loads(artifact.to_json()))
     assert restored.strategy_revision_id is None
     assert restored.strategy_revision is None
+
+
+# ---------------------------------------------------------------------------
+# v1.3.0 — max_leverage_envelope (P1.5-AC2 / #252)
+# ---------------------------------------------------------------------------
+
+
+def _v4_artifact_with_envelope() -> CharacterizationArtifact:
+    """Helper — v1.3.0 artifact carrying both the v1.2 revision and the new
+    v1.3 max_leverage_envelope field."""
+    return CharacterizationArtifact(
+        schema_version="1.3.0",
+        strategy_id="momentum_pulse",
+        symbol="BTCUSDT",
+        period="15m",
+        range_from="2026-01-01T00:00:00+00:00",
+        range_to="2026-01-05T00:00:00+00:00",
+        candle_count=4,
+        signal_count=1,
+        source="backtest",
+        events=(
+            BacktestEvent(
+                decision_id="dec_20260101T000000000_abc123",
+                candle_timestamp="2026-01-01T00:00:00+00:00",
+                action="buy",
+                confidence=0.74,
+                current_price=50000.0,
+                metadata={},
+            ),
+        ),
+        edge_estimate=EdgeEstimate(
+            expected_pnl=0.02, win_rate=1.0, sharpe_ratio=0.0, trade_count=1
+        ),
+        drawdown_envelope=DrawdownEnvelope(p50=0.0, p90=0.0, p99=0.02, p100=0.05),
+        sensitivity_analysis=SensitivityAnalysis(
+            parameter="confidence_threshold",
+            points=(
+                SensitivityPoint(
+                    confidence_threshold=0.0,
+                    win_rate=1.0,
+                    expected_pnl=0.02,
+                    trade_count=1,
+                ),
+            ),
+        ),
+        strategy_revision_id="srev_abc123abc123_def456def456",
+        strategy_revision=StrategyRevision(
+            strategy_id="momentum_pulse",
+            revision_id="srev_abc123abc123_def456def456",
+            module_hash="abc123abc123" + "0" * 52,
+            parameter_hash="def456def456" + "0" * 52,
+        ),
+        max_leverage_envelope=5.0,
+    )
+
+
+@pytest.mark.unit
+def test_v4_to_json_contains_max_leverage_envelope() -> None:
+    artifact = _v4_artifact_with_envelope()
+    parsed = json.loads(artifact.to_json())
+    assert parsed["schema_version"] == "1.3.0"
+    assert parsed["max_leverage_envelope"] == 5.0
+
+
+@pytest.mark.unit
+def test_v4_from_json_roundtrip() -> None:
+    artifact = _v4_artifact_with_envelope()
+    restored = CharacterizationArtifact.from_json(artifact.to_json())
+    assert restored == artifact
+    assert restored.max_leverage_envelope == 5.0
+
+
+@pytest.mark.unit
+def test_legacy_v1_load_leaves_max_leverage_envelope_none() -> None:
+    artifact = _v1_artifact()
+    restored = CharacterizationArtifact.from_dict(json.loads(artifact.to_json()))
+    assert restored.max_leverage_envelope is None
+
+
+@pytest.mark.unit
+def test_legacy_v2_load_leaves_max_leverage_envelope_none() -> None:
+    artifact = _v2_artifact()
+    restored = CharacterizationArtifact.from_dict(json.loads(artifact.to_json()))
+    assert restored.max_leverage_envelope is None
+
+
+@pytest.mark.unit
+def test_legacy_v3_load_leaves_max_leverage_envelope_none() -> None:
+    artifact = _v3_artifact_with_revision()
+    restored = CharacterizationArtifact.from_dict(json.loads(artifact.to_json()))
+    assert restored.max_leverage_envelope is None
+
+
+@pytest.mark.unit
+def test_int_max_leverage_envelope_coerced_to_float() -> None:
+    """JSON ints (e.g. 5) must deserialize as a float so consumers comparing
+    against `>= 1.0` thresholds don't trip on a stray int."""
+    base = _v4_artifact_with_envelope()
+    payload = json.loads(base.to_json())
+    payload["max_leverage_envelope"] = 7  # JSON int, not 7.0
+    restored = CharacterizationArtifact.from_dict(payload)
+    assert restored.max_leverage_envelope == 7.0
+    assert isinstance(restored.max_leverage_envelope, float)

--- a/tests/backtest/test_engine_e2e.py
+++ b/tests/backtest/test_engine_e2e.py
@@ -61,8 +61,9 @@ def test_backtest_emits_artifact_from_recorded_fixture() -> None:
         assert event.action in {"buy", "sell", "hold", "close"}
         assert 0.0 <= event.confidence <= 1.0
 
-    # v1.2.0 analytic fields must be present and structurally valid (AC1–AC3, AC4)
-    assert artifact.schema_version == ARTIFACT_SCHEMA_VERSION == "1.2.0"
+    # v1.3.0 analytic fields must be present and structurally valid
+    # (AC1–AC3, AC4 from #131, plus max_leverage_envelope from #252 AC2.c).
+    assert artifact.schema_version == ARTIFACT_SCHEMA_VERSION == "1.3.0"
     assert isinstance(artifact.edge_estimate, EdgeEstimate)
     assert isinstance(artifact.drawdown_envelope, DrawdownEnvelope)
     assert isinstance(artifact.sensitivity_analysis, SensitivityAnalysis)
@@ -72,6 +73,11 @@ def test_backtest_emits_artifact_from_recorded_fixture() -> None:
     assert artifact.drawdown_envelope.p90 <= artifact.drawdown_envelope.p100
     assert artifact.sensitivity_analysis.parameter == "confidence_threshold"
     assert len(artifact.sensitivity_analysis.points) == 5
+    # P1.5-AC2.c (#252): every produced artifact carries a non-None envelope
+    # bounded by the operator-configured maximum (no implicit unbounded leverage).
+    assert isinstance(artifact.max_leverage_envelope, float)
+    assert artifact.max_leverage_envelope >= 0.0
+    assert artifact.max_leverage_envelope <= 10.0  # DEFAULT_OPERATOR_MAX_LEVERAGE
 
     # FR53 strategy-revision binding (P3.4 AC1/AC2): every emitted artifact
     # carries the content-addressable revision of the producing strategy.


### PR DESCRIPTION
## Summary

Implements **AC2** of EPIC [petrosa_k8s#691](https://github.com/PetroSa2/petrosa_k8s/issues/691). Every characterization artifact now records the analytic max leverage that does not breach the strategy's drawdown envelope — becomes the producer-side upper bound for the `recommended_leverage` signal field shipped in [#251](https://github.com/PetroSa2/petrosa-bot-ta-analysis/issues/251).

Closes [#252](https://github.com/PetroSa2/petrosa-bot-ta-analysis/issues/252).

### AC2.a — Schema field
`max_leverage_envelope: float | None` added to `CharacterizationArtifact` (schema bumped to **v1.3.0**). Optional on load so v1.0/v1.1/v1.2 artifacts continue to deserialize with `max_leverage_envelope=None`.

### AC2.b — Analytic helper
`compute_max_leverage_envelope(events, drawdown_envelope, budget, operator_max) -> float` in `backtest/analytics.py`. Formula: `min(operator_max, budget / p99)`. Properties locked by unit tests:
- monotone in budget (more budget → more leverage)
- inverse-monotone in p99 drawdown (more drawdown → less leverage)
- zero-drawdown corner case caps at `operator_max` (no implicit infinity)
- zero-budget returns 0.0 (operator can pin to no leverage)
- negative inputs clipped to zero (defensive)

### AC2.c — Engine wires it
`BacktestEngine` computes the envelope once per artifact alongside `drawdown_envelope` and persists via `ArtifactPersister` — same pattern as #250 strategy-revision binding.

### AC2.d — Tests
13 new tests covering:
- Analytics monotonicity + corner cases (7 tests in `test_analytics.py`)
- Artifact round-trip + backwards-compat for v1.0/v1.1/v1.2/v1.3 + JSON int coercion (6 tests in `test_artifact.py`)
- e2e expectation updated: produced artifacts MUST carry a non-None envelope within `[0, operator_max]`.

## Test plan
- [x] `make test` — **697/697 pass** (was 684; +13 new)
- [x] `make lint` — clean
- [x] `make security` — clean for new code
- [ ] Manual: regenerate a fixture artifact, verify `max_leverage_envelope` is populated and `min(10.0, budget/p99)` matches the formula
- [ ] Sibling work: petrosa-data-manager#182 (operator-configurable bounds) will let operators override the producer-side defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)