### PR TITLE
feat(cli): FR54-A strategy submission + backtest CLI (#255)

### DIFF
--- a/ta_bot/cli_strategy.py
+++ b/ta_bot/cli_strategy.py
@@ -1,0 +1,227 @@
+"""Strategy submission CLI for FR54-A (petrosa-bot-ta-analysis#255).
+
+Subcommands:
+
+* ``submit`` — POSTs a strategy definition to
+  ``petrosa-data-manager`` at ``POST /api/strategies`` and prints the
+  registered ``strategy_id`` on success.
+* ``backtest`` — thin shim over the existing ``python -m backtest`` CLI
+  (``backtest.cli.main``); forwards ``--strategy/--from/--to/...`` so a
+  freshly-submitted candidate can be replayed in one workflow.
+
+The submission payload is **persisted verbatim by the registry**;
+``petrosa-data-manager`` never imports, compiles, or executes the code
+(see ``petrosa-data-manager/data_manager/models/registered_strategy.py``).
+Code-execution sandboxing for the backtest happens entirely on the
+caller side via the existing ``backtest.engine.BacktestEngine`` machinery.
+
+Invocation::
+
+    python -m ta_bot.cli_strategy submit \
+        --strategy-id momentum-v3 \
+        --code-file ./strategies/momentum_v3.py \
+        --params '{"window": 14, "threshold": 0.03}' \
+        --symbols BTCUSDT,ETHUSDT \
+        --submitted-by alice \
+        --signed-action-id sa-1
+
+    python -m ta_bot.cli_strategy backtest \
+        --strategy momentum-v3 \
+        --from 2026-05-01 --to 2026-05-15 --symbol BTCUSDT
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DATA_MANAGER_URL = os.environ.get(
+    "DATA_MANAGER_URL", "http://petrosa-data-manager:8000"
+)
+STRATEGIES_PATH = "/api/strategies"
+
+
+def _parse_symbol_scope(raw: str) -> list[str]:
+    parts = [s.strip() for s in raw.split(",") if s.strip()]
+    if not parts:
+        raise argparse.ArgumentTypeError("--symbols must list at least one symbol")
+    return parts
+
+
+def _parse_parameter_set(raw: str) -> dict[str, Any]:
+    try:
+        obj = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--params must be valid JSON object: {exc.msg}"
+        ) from exc
+    if not isinstance(obj, dict):
+        raise argparse.ArgumentTypeError("--params must be a JSON object")
+    return obj
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ta_bot.cli_strategy",
+        description=(
+            "Self-service strategy submission + backtest CLI (FR54-A). "
+            "Submits a strategy definition to petrosa-data-manager and/or "
+            "runs the existing backtest engine against historical data."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    submit = sub.add_parser(
+        "submit",
+        help="POST a strategy definition to petrosa-data-manager",
+    )
+    submit.add_argument(
+        "--strategy-id", required=True, help="Stable identifier (e.g. momentum-v3)"
+    )
+    submit.add_argument(
+        "--code-file",
+        required=True,
+        type=Path,
+        help="Path to a .py file containing the strategy code (persisted verbatim, never executed by the registry)",
+    )
+    submit.add_argument(
+        "--params",
+        required=True,
+        type=_parse_parameter_set,
+        help="Parameter set as JSON object (e.g. '{\"window\": 14}')",
+    )
+    submit.add_argument(
+        "--symbols",
+        required=True,
+        type=_parse_symbol_scope,
+        help="Comma-separated symbol scope (e.g. BTCUSDT,ETHUSDT)",
+    )
+    submit.add_argument(
+        "--submitted-by",
+        required=True,
+        help="Operator handle (audit-trail field)",
+    )
+    submit.add_argument(
+        "--signed-action-id",
+        required=True,
+        help="Signed-action audit ID for the submission",
+    )
+    submit.add_argument(
+        "--data-manager-url",
+        default=DEFAULT_DATA_MANAGER_URL,
+        help=f"Base URL for petrosa-data-manager (default: {DEFAULT_DATA_MANAGER_URL} or $DATA_MANAGER_URL)",
+    )
+    submit.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="HTTP timeout in seconds (default 30)",
+    )
+
+    # ``backtest`` is intentionally a thin pass-through: it forwards every
+    # arg after the subcommand verbatim to ``backtest.cli.main`` without
+    # re-parsing. We don't register it on the subparser because argparse's
+    # REMAINDER positional eagerly consumes options as the parent parser's
+    # unknown args. ``main()`` short-circuits ``argv[0] == 'backtest'``.
+    sub.add_parser(
+        "backtest",
+        help="Delegate to the existing backtest CLI (python -m backtest); "
+        "all subsequent args are forwarded verbatim to backtest.cli.main.",
+        add_help=False,
+    )
+
+    return parser
+
+
+def _submit_payload(args: argparse.Namespace) -> dict[str, Any]:
+    code = args.code_file.read_text(encoding="utf-8")
+    return {
+        "strategy_id": args.strategy_id,
+        "code": code,
+        "parameter_set": args.params,
+        "symbol_scope": args.symbols,
+        "submitted_by": args.submitted_by,
+        "signed_action_id": args.signed_action_id,
+    }
+
+
+def _post_strategy(
+    url: str,
+    payload: dict[str, Any],
+    timeout: float,
+    opener: urllib.request.OpenerDirector | None = None,
+) -> dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    op = opener or urllib.request.build_opener()
+    with op.open(req, timeout=timeout) as resp:
+        raw = resp.read()
+        status = getattr(resp, "status", None) or resp.getcode()
+        text = raw.decode("utf-8") if raw else ""
+        if status < 200 or status >= 300:
+            raise RuntimeError(f"Strategy submission failed: HTTP {status}: {text}")
+        try:
+            return json.loads(text) if text else {}
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Strategy submission returned non-JSON response: {text!r}"
+            ) from exc
+
+
+def run_submit(args: argparse.Namespace) -> int:
+    if not args.code_file.exists():
+        print(f"error: --code-file not found: {args.code_file}", file=sys.stderr)
+        return 2
+    payload = _submit_payload(args)
+    url = args.data_manager_url.rstrip("/") + STRATEGIES_PATH
+    try:
+        result = _post_strategy(url, payload, args.timeout)
+    except urllib.error.HTTPError as e:
+        try:
+            err_text = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            err_text = ""
+        print(f"error: HTTP {e.code} from {url}: {err_text}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"error: cannot reach {url}: {e.reason}", file=sys.stderr)
+        return 1
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def run_backtest(forwarded: Sequence[str]) -> int:
+    from backtest.cli import main as backtest_main
+
+    return backtest_main(list(forwarded))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    raw = list(sys.argv[1:] if argv is None else argv)
+    if raw and raw[0] == "backtest":
+        return run_backtest(raw[1:])
+    parser = build_parser()
+    args = parser.parse_args(raw)
+    if args.command == "submit":
+        return run_submit(args)
+    parser.print_help(sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover — entry point
+    sys.exit(main())

--- a/tests/test_cli_strategy.py
+++ b/tests/test_cli_strategy.py
@@ -154,6 +154,101 @@ def test_parse_parameter_set_rejects_non_object() -> None:
     assert "JSON object" in str(exc_info.value)
 
 
+def test_parse_parameter_set_rejects_invalid_json() -> None:
+    import argparse as _ap
+
+    with pytest.raises(_ap.ArgumentTypeError) as exc_info:
+        cli_strategy._parse_parameter_set("{not json")
+    assert "valid JSON object" in str(exc_info.value)
+
+
+def test_run_submit_returns_1_on_url_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import urllib.error as _err
+
+    code_path = _write_sample_strategy(tmp_path)
+
+    class _ErroringOpener:
+        def open(self, req: Any, timeout: float = 0) -> Any:
+            raise _err.URLError("connection refused")
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _ErroringOpener(),
+    )
+    rc = cli_strategy.main(
+        [
+            "submit",
+            "--strategy-id",
+            "x",
+            "--code-file",
+            str(code_path),
+            "--params",
+            "{}",
+            "--symbols",
+            "BTCUSDT",
+            "--submitted-by",
+            "alice",
+            "--signed-action-id",
+            "sa-1",
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "cannot reach" in err
+
+
+def test_run_submit_returns_1_on_http_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import urllib.error as _err
+
+    code_path = _write_sample_strategy(tmp_path)
+
+    class _HttpErroringOpener:
+        def open(self, req: Any, timeout: float = 0) -> Any:
+            raise _err.HTTPError(
+                req.full_url,
+                503,
+                "Service Unavailable",
+                {},
+                io.BytesIO(b'{"detail":"mongo down"}'),
+            )
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _HttpErroringOpener(),
+    )
+    rc = cli_strategy.main(
+        [
+            "submit",
+            "--strategy-id",
+            "x",
+            "--code-file",
+            str(code_path),
+            "--params",
+            "{}",
+            "--symbols",
+            "BTCUSDT",
+            "--submitted-by",
+            "alice",
+            "--signed-action-id",
+            "sa-1",
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "HTTP 503" in err
+    assert "mongo down" in err
+
+
 # ─── parser wiring ───────────────────────────────────────────────────────────
 
 

--- a/tests/test_cli_strategy.py
+++ b/tests/test_cli_strategy.py
@@ -1,0 +1,275 @@
+"""Tests for ``ta_bot/cli_strategy.py`` (FR54-A, #255)."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ta_bot import cli_strategy
+
+
+def _write_sample_strategy(tmp_path: Path) -> Path:
+    p = tmp_path / "momentum_v3.py"
+    p.write_text("def signal(*a, **kw):\n    return None\n", encoding="utf-8")
+    return p
+
+
+class _FakeResponse:
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def getcode(self) -> int:
+        return self.status
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+
+class _FakeOpener:
+    def __init__(self, response: _FakeResponse) -> None:
+        self.response = response
+        self.requests: list[dict[str, Any]] = []
+
+    def open(self, req: Any, timeout: float = 0) -> _FakeResponse:
+        self.requests.append(
+            {
+                "url": req.full_url,
+                "method": req.get_method(),
+                "headers": dict(req.header_items()),
+                "body": req.data,
+                "timeout": timeout,
+            }
+        )
+        return self.response
+
+
+# ─── _submit_payload ──────────────────────────────────────────────────────────
+
+
+def test_submit_payload_reads_code_file_and_assembles_request(tmp_path: Path) -> None:
+    code_path = _write_sample_strategy(tmp_path)
+    args = cli_strategy.build_parser().parse_args(
+        [
+            "submit",
+            "--strategy-id",
+            "momentum-v3",
+            "--code-file",
+            str(code_path),
+            "--params",
+            '{"window": 14, "threshold": 0.03}',
+            "--symbols",
+            "BTCUSDT,ETHUSDT",
+            "--submitted-by",
+            "alice",
+            "--signed-action-id",
+            "sa-1",
+        ]
+    )
+    payload = cli_strategy._submit_payload(args)
+    assert payload == {
+        "strategy_id": "momentum-v3",
+        "code": "def signal(*a, **kw):\n    return None\n",
+        "parameter_set": {"window": 14, "threshold": 0.03},
+        "symbol_scope": ["BTCUSDT", "ETHUSDT"],
+        "submitted_by": "alice",
+        "signed_action_id": "sa-1",
+    }
+
+
+# ─── _post_strategy ──────────────────────────────────────────────────────────
+
+
+def test_post_strategy_sends_json_and_returns_parsed_body() -> None:
+    response_body = json.dumps(
+        {
+            "strategy_id": "momentum-v3",
+            "status": "candidate",
+            "registered_at": "2026-05-30T22:00:00Z",
+        }
+    ).encode("utf-8")
+    fake = _FakeOpener(_FakeResponse(201, response_body))
+    result = cli_strategy._post_strategy(
+        "http://dm.local/api/strategies",
+        {"strategy_id": "momentum-v3"},
+        timeout=5.0,
+        opener=fake,
+    )
+    assert result["strategy_id"] == "momentum-v3"
+    assert result["status"] == "candidate"
+    assert len(fake.requests) == 1
+    sent = fake.requests[0]
+    assert sent["url"] == "http://dm.local/api/strategies"
+    assert sent["method"] == "POST"
+    header_pairs = {(k.lower(), v) for k, v in sent["headers"].items()}
+    assert ("content-type", "application/json") in header_pairs
+    assert json.loads(sent["body"].decode("utf-8")) == {"strategy_id": "momentum-v3"}
+
+
+def test_post_strategy_raises_on_non_2xx() -> None:
+    fake = _FakeOpener(_FakeResponse(500, b'{"detail":"boom"}'))
+    with pytest.raises(RuntimeError, match="HTTP 500") as exc_info:
+        cli_strategy._post_strategy(
+            "http://dm.local/api/strategies",
+            {"strategy_id": "x"},
+            timeout=5.0,
+            opener=fake,
+        )
+    assert "HTTP 500" in str(exc_info.value)
+
+
+# ─── parameter / symbol validators ───────────────────────────────────────────
+
+
+def test_parse_symbol_scope_accepts_csv_and_strips() -> None:
+    assert cli_strategy._parse_symbol_scope("BTCUSDT, ETHUSDT") == [
+        "BTCUSDT",
+        "ETHUSDT",
+    ]
+
+
+def test_parse_symbol_scope_rejects_empty() -> None:
+    import argparse as _ap
+
+    with pytest.raises(_ap.ArgumentTypeError) as exc_info:
+        cli_strategy._parse_symbol_scope("   ,  ")
+    assert "at least one symbol" in str(exc_info.value)
+
+
+def test_parse_parameter_set_rejects_non_object() -> None:
+    import argparse as _ap
+
+    with pytest.raises(_ap.ArgumentTypeError) as exc_info:
+        cli_strategy._parse_parameter_set("[1,2,3]")
+    assert "JSON object" in str(exc_info.value)
+
+
+# ─── parser wiring ───────────────────────────────────────────────────────────
+
+
+def test_parser_requires_subcommand() -> None:
+    parser = cli_strategy.build_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([])
+    assert exc_info.value.code == 2
+
+
+def test_backtest_subcommand_forwards_remaining(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[Any] = []
+
+    def _fake_backtest_main(argv: Any) -> int:
+        captured.append(argv)
+        return 0
+
+    import sys
+
+    fake_backtest_module = type(sys)("backtest")
+    fake_cli_module = type(sys)("backtest.cli")
+    fake_cli_module.main = _fake_backtest_main  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "backtest", fake_backtest_module)
+    monkeypatch.setitem(sys.modules, "backtest.cli", fake_cli_module)
+
+    rc = cli_strategy.main(
+        [
+            "backtest",
+            "--strategy",
+            "momentum-v3",
+            "--from",
+            "2026-05-01",
+            "--to",
+            "2026-05-02",
+        ]
+    )
+    assert rc == 0
+    assert captured == [
+        ["--strategy", "momentum-v3", "--from", "2026-05-01", "--to", "2026-05-02"]
+    ]
+
+
+# ─── end-to-end submit (mock HTTP) ───────────────────────────────────────────
+
+
+def test_run_submit_happy_path_prints_response_and_returns_zero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code_path = _write_sample_strategy(tmp_path)
+    response_body = json.dumps(
+        {
+            "strategy_id": "momentum-v3",
+            "status": "candidate",
+            "registered_at": "2026-05-30T22:00:00Z",
+        }
+    ).encode("utf-8")
+    fake = _FakeOpener(_FakeResponse(201, response_body))
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: fake,
+    )
+    rc = cli_strategy.main(
+        [
+            "submit",
+            "--strategy-id",
+            "momentum-v3",
+            "--code-file",
+            str(code_path),
+            "--params",
+            '{"window": 14}',
+            "--symbols",
+            "BTCUSDT",
+            "--submitted-by",
+            "alice",
+            "--signed-action-id",
+            "sa-1",
+            "--data-manager-url",
+            "http://dm.local/",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    printed = json.loads(out)
+    assert printed["strategy_id"] == "momentum-v3"
+    assert printed["status"] == "candidate"
+    assert len(fake.requests) == 1
+    sent_url = fake.requests[0]["url"]
+    assert sent_url == "http://dm.local/api/strategies"
+
+
+def test_run_submit_returns_2_when_code_file_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = cli_strategy.main(
+        [
+            "submit",
+            "--strategy-id",
+            "x",
+            "--code-file",
+            str(tmp_path / "does-not-exist.py"),
+            "--params",
+            "{}",
+            "--symbols",
+            "BTCUSDT",
+            "--submitted-by",
+            "alice",
+            "--signed-action-id",
+            "sa-1",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "not found" in err


### PR DESCRIPTION
Closes #255.

## What

Adds `ta_bot/cli_strategy.py` — a thin argparse CLI exposing two subcommands:

| Subcommand | Behavior |
|---|---|
| `submit` | `POST /api/strategies` to petrosa-data-manager with `{strategy_id, code, parameter_set, symbol_scope, submitted_by, signed_action_id}`, prints the registered response JSON, returns 0/1/2 on success/HTTP-error/missing-code-file. |
| `backtest` | Verbatim passthrough to the existing `backtest.cli.main` (no re-parsing — `cli_strategy.main` short-circuits when `argv[0] == 'backtest'`). |

## Why

FR54 of the P5.3 PRD: operators should be able to register a new strategy AND backtest it from a single CLI without editing checked-in Python files or k8s manifests. Submission goes through the registry shipped in petrosa-data-manager PR #198; the registry **persists code verbatim, never executes it** (per the model docstring in `data_manager/models/registered_strategy.py`).

## Acceptance criteria

- [x] **AC1 — Submission entry point**: `submit` POSTs the canonical 6-field payload to `/api/strategies` and prints the response. Verified by `test_run_submit_happy_path_prints_response_and_returns_zero` and `test_submit_payload_reads_code_file_and_assembles_request`.
- [x] **AC2 — Backtest trigger**: `backtest` invokes `backtest.cli.main` with all forwarded args. Verified by `test_backtest_subcommand_forwards_remaining` (monkeypatched `backtest.cli.main`).
- [x] **AC3 — Zero-shim slice**: the strategy code travels in the submission payload (`code` field). The CLI module itself is infrastructure, not a strategy — no checked-in symbol-specific Python files are required to register or backtest a strategy via this surface.
- [x] **AC4 — Integration test**: end-to-end happy-path test exercises arg parsing, code-file read, HTTP request assembly, response parsing, and stdout JSON output via fake-opener mock.

## Scope

- One source file: `ta_bot/cli_strategy.py` (+223 LOC)
- One test file: `tests/test_cli_strategy.py` (+10 tests)
- Zero new runtime dependencies (stdlib `urllib.request` for the POST)
- Invocation: `python -m ta_bot.cli_strategy {submit,backtest} ...` (the ticket's `bot-ta strategy ...` framing is illustrative — promoting to a console_script entry can land in a follow-up if desired)

## Test plan

```
$ .venv/bin/python -m pytest tests/test_cli_strategy.py
10 passed in 0.02s

$ .venv/bin/python -m pytest
707 passed, 5 skipped in 14.09s

$ .venv/bin/python -m ruff check ta_bot/cli_strategy.py tests/test_cli_strategy.py
All checks passed!
```

## Out of scope (per ticket)

- FR54-B characterization persist + CIO admission → #256
- FR54-C lifecycle status query + parent AC6 zero-shim verification → #257
- Dashboard surface (deferred per ADR pending petrosa_k8s#657)
