### PR TITLE
feat(cli): FR54-C lifecycle status query (#257, partial)

### DIFF
--- a/ta_bot/cli_strategy.py
+++ b/ta_bot/cli_strategy.py
@@ -137,6 +137,23 @@ def build_parser() -> argparse.ArgumentParser:
         add_help=False,
     )
 
+    status = sub.add_parser(
+        "status",
+        help="GET /api/strategies/{strategy_id} and print the registered document (FR54-C, #257)",
+    )
+    status.add_argument("--strategy-id", required=True, help="Strategy ID to query")
+    status.add_argument(
+        "--data-manager-url",
+        default=DEFAULT_DATA_MANAGER_URL,
+        help=f"Base URL for petrosa-data-manager (default: {DEFAULT_DATA_MANAGER_URL} or $DATA_MANAGER_URL)",
+    )
+    status.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="HTTP timeout in seconds (default 30)",
+    )
+
     return parser
 
 
@@ -211,6 +228,62 @@ def run_backtest(forwarded: Sequence[str]) -> int:
     return backtest_main(list(forwarded))
 
 
+def _get_strategy(
+    url: str,
+    timeout: float,
+    opener: urllib.request.OpenerDirector | None = None,
+) -> dict[str, Any]:
+    """GET the strategy document. Mirrors :func:`_post_strategy` for the read side
+    so the lifecycle status query (FR54-C) uses the same urllib transport
+    contract as the submit path.
+    """
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={"Accept": "application/json"},
+    )
+    op = opener or urllib.request.build_opener()
+    with op.open(req, timeout=timeout) as resp:
+        raw = resp.read()
+        status = getattr(resp, "status", None) or resp.getcode()
+        text = raw.decode("utf-8") if raw else ""
+        if status < 200 or status >= 300:
+            raise RuntimeError(f"Strategy status query failed: HTTP {status}: {text}")
+        try:
+            return json.loads(text) if text else {}
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Strategy status returned non-JSON response: {text!r}"
+            ) from exc
+
+
+def run_status(args: argparse.Namespace) -> int:
+    url = args.data_manager_url.rstrip("/") + STRATEGIES_PATH + "/" + args.strategy_id
+    try:
+        result = _get_strategy(url, args.timeout)
+    except urllib.error.HTTPError as e:
+        try:
+            err_text = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            err_text = ""
+        # 404 is a normal "not registered" answer in the lifecycle context;
+        # surface it explicitly to the operator with a distinct exit code so a
+        # CI script can disambiguate "doesn't exist" from "transport failure".
+        if e.code == 404:
+            print(f"error: strategy {args.strategy_id!r} not found", file=sys.stderr)
+            return 3
+        print(f"error: HTTP {e.code} from {url}: {err_text}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"error: cannot reach {url}: {e.reason}", file=sys.stderr)
+        return 1
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     raw = list(sys.argv[1:] if argv is None else argv)
     if raw and raw[0] == "backtest":
@@ -219,6 +292,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(raw)
     if args.command == "submit":
         return run_submit(args)
+    if args.command == "status":
+        return run_status(args)
     parser.print_help(sys.stderr)
     return 2
 

--- a/tests/test_cli_strategy.py
+++ b/tests/test_cli_strategy.py
@@ -313,6 +313,58 @@ def test_get_strategy_raises_on_non_2xx() -> None:
     assert "HTTP 500" in str(exc_info.value)
 
 
+def test_get_strategy_raises_on_non_json_body() -> None:
+    fake = _FakeOpener(_FakeResponse(200, b"not-json"))
+    with pytest.raises(RuntimeError, match="non-JSON") as exc_info:
+        cli_strategy._get_strategy(
+            "http://dm.local/api/strategies/x", timeout=5.0, opener=fake
+        )
+    assert "non-JSON" in str(exc_info.value)
+
+
+def test_run_status_returns_1_on_url_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import urllib.error as _err
+
+    class _ErrOpener:
+        def open(self, req: Any, timeout: float = 0) -> Any:
+            raise _err.URLError("connection refused")
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _ErrOpener(),
+    )
+    rc = cli_strategy.main(
+        ["status", "--strategy-id", "x", "--data-manager-url", "http://dm.local"]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "cannot reach" in err
+
+
+def test_run_status_returns_1_on_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_get_strategy raises RuntimeError if the response body isn't JSON;
+    run_status converts that to exit 1 with the error message."""
+    fake = _FakeOpener(_FakeResponse(200, b"not-json-not-anything"))
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: fake,
+    )
+    rc = cli_strategy.main(
+        ["status", "--strategy-id", "x", "--data-manager-url", "http://dm.local"]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "non-JSON" in err
+
+
 def test_run_submit_returns_1_on_http_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli_strategy.py
+++ b/tests/test_cli_strategy.py
@@ -202,6 +202,117 @@ def test_run_submit_returns_1_on_url_error(
     assert "cannot reach" in err
 
 
+# ─── status subcommand (FR54-C, #257) ────────────────────────────────────────
+
+
+def test_run_status_happy_path_prints_response_and_returns_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    response_body = json.dumps(
+        {
+            "strategy_id": "momentum-v3",
+            "status": "candidate",
+            "registered_at": "2026-05-30T22:00:00Z",
+            "version": 1,
+        }
+    ).encode("utf-8")
+    fake = _FakeOpener(_FakeResponse(200, response_body))
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: fake,
+    )
+    rc = cli_strategy.main(
+        [
+            "status",
+            "--strategy-id",
+            "momentum-v3",
+            "--data-manager-url",
+            "http://dm.local/",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    printed = json.loads(out)
+    assert printed["strategy_id"] == "momentum-v3"
+    assert printed["status"] == "candidate"
+    assert len(fake.requests) == 1
+    assert fake.requests[0]["url"] == "http://dm.local/api/strategies/momentum-v3"
+    assert fake.requests[0]["method"] == "GET"
+
+
+def test_run_status_returns_3_on_404_distinct_from_other_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import urllib.error as _err
+
+    class _NotFoundOpener:
+        def open(self, req: Any, timeout: float = 0) -> Any:
+            raise _err.HTTPError(
+                req.full_url,
+                404,
+                "Not Found",
+                {},
+                io.BytesIO(b'{"detail":"unknown strategy"}'),
+            )
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _NotFoundOpener(),
+    )
+    rc = cli_strategy.main(
+        ["status", "--strategy-id", "ghost", "--data-manager-url", "http://dm.local"]
+    )
+    assert rc == 3
+    err = capsys.readouterr().err
+    assert "'ghost' not found" in err
+
+
+def test_run_status_returns_1_on_5xx(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import urllib.error as _err
+
+    class _ErrOpener:
+        def open(self, req: Any, timeout: float = 0) -> Any:
+            raise _err.HTTPError(req.full_url, 503, "boom", {}, io.BytesIO(b"down"))
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _ErrOpener(),
+    )
+    rc = cli_strategy.main(
+        ["status", "--strategy-id", "x", "--data-manager-url", "http://dm.local"]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "HTTP 503" in err
+
+
+def test_get_strategy_sends_get_and_returns_body() -> None:
+    body = json.dumps({"strategy_id": "abc", "status": "accepted"}).encode("utf-8")
+    fake = _FakeOpener(_FakeResponse(200, body))
+    result = cli_strategy._get_strategy(
+        "http://dm.local/api/strategies/abc", timeout=5.0, opener=fake
+    )
+    assert result["strategy_id"] == "abc"
+    assert fake.requests[0]["method"] == "GET"
+
+
+def test_get_strategy_raises_on_non_2xx() -> None:
+    fake = _FakeOpener(_FakeResponse(500, b'{"detail":"boom"}'))
+    with pytest.raises(RuntimeError, match="HTTP 500") as exc_info:
+        cli_strategy._get_strategy(
+            "http://dm.local/api/strategies/x", timeout=5.0, opener=fake
+        )
+    assert "HTTP 500" in str(exc_info.value)
+
+
 def test_run_submit_returns_1_on_http_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Implements FR54-C **AC1 (lifecycle status query) only**. AC2 (zero-shim verification integration test) is deferred — it requires the full FR54-A → B → C chain working end-to-end, and FR54-B (#256) is blocked on data-manager POST /api/characterizations + cio admission HTTP endpoint gaps.

## What

Adds `status` subcommand to `python -m ta_bot.cli_strategy`:

```
$ python -m ta_bot.cli_strategy status --strategy-id momentum-v3
{"strategy_id": "momentum-v3", "status": "candidate", "registered_at": "..."}
```

- GET `/api/strategies/{strategy_id}` on petrosa-data-manager
- Exit codes: 0 (found), 1 (transport/5xx), 3 (404 not-found — distinct so CI can disambiguate)
- 5 new tests (happy path, 404 → exit 3, 5xx → exit 1, helper request shape, helper raises on non-2xx)
- Full file suite 18/18, ruff clean

## Scope guard

| AC | Status |
|---|---|
| AC1 — lifecycle status query | ✅ shipped here |
| AC2 — zero-shim verification | ⏸ deferred, blocked by #256 precondition gaps |

When #256 unblocks and ships, the AC2 verification can land as a follow-up integration test in this CLI module.

Closes part of #257; remaining AC2 work tracked in the ticket as a follow-up.