### PR TITLE
feat(cli): FR54-B characterization persist + CIO admission (#256)

### DIFF
--- a/ta_bot/cli_strategy.py
+++ b/ta_bot/cli_strategy.py
@@ -1,4 +1,4 @@
-"""Strategy submission CLI for FR54-A (petrosa-bot-ta-analysis#255).
+"""Strategy submission CLI for FR54 (petrosa-bot-ta-analysis #255 / #257 / #256).
 
 Subcommands:
 
@@ -8,31 +8,33 @@ Subcommands:
 * ``backtest`` — thin shim over the existing ``python -m backtest`` CLI
   (``backtest.cli.main``); forwards ``--strategy/--from/--to/...`` so a
   freshly-submitted candidate can be replayed in one workflow.
+* ``status`` — GET ``/api/strategies/{id}`` and print the persisted
+  document. Exit code 3 disambiguates "strategy not registered" (404)
+  from "transport failure" (1).
+* ``persist-characterization`` (FR54-B AC1, #256) — maps a
+  ``CharacterizationArtifact`` JSON produced by the ``backtest``
+  subcommand into the ``Characterization`` shape that
+  ``petrosa-data-manager`` persists, then POSTs to
+  ``POST /api/characterizations``. The data-manager upsert is keyed by
+  ``(strategy_id, strategy_version)`` so re-POSTing the same artifact is
+  a natural no-op (AC3).
+* ``register-with-cio`` (FR54-B AC2, #256) — POSTs to
+  ``POST /api/admission/register`` on ``petrosa-cio``. The receiving
+  ``PortfolioTracker.record_admit`` replaces the per-strategy position
+  in a dict, so re-registering the same ``strategy_id`` is also a
+  natural no-op (AC3).
 
 The submission payload is **persisted verbatim by the registry**;
 ``petrosa-data-manager`` never imports, compiles, or executes the code
 (see ``petrosa-data-manager/data_manager/models/registered_strategy.py``).
 Code-execution sandboxing for the backtest happens entirely on the
 caller side via the existing ``backtest.engine.BacktestEngine`` machinery.
-
-Invocation::
-
-    python -m ta_bot.cli_strategy submit \
-        --strategy-id momentum-v3 \
-        --code-file ./strategies/momentum_v3.py \
-        --params '{"window": 14, "threshold": 0.03}' \
-        --symbols BTCUSDT,ETHUSDT \
-        --submitted-by alice \
-        --signed-action-id sa-1
-
-    python -m ta_bot.cli_strategy backtest \
-        --strategy momentum-v3 \
-        --from 2026-05-01 --to 2026-05-15 --symbol BTCUSDT
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -45,7 +47,18 @@ from typing import Any
 DEFAULT_DATA_MANAGER_URL = os.environ.get(
     "DATA_MANAGER_URL", "http://petrosa-data-manager:8000"
 )
+DEFAULT_CIO_URL = os.environ.get("CIO_URL", "http://petrosa-cio:8000")
 STRATEGIES_PATH = "/api/strategies"
+CHARACTERIZATIONS_PATH = "/api/characterizations"
+CIO_ADMISSION_REGISTER_PATH = "/api/admission/register"
+
+# FR54-B AC1: required edge-metric keys on the data-manager
+# ``Characterization`` shape (mirrors
+# ``data_manager/models/characterization.REQUIRED_METRIC_KEYS``). The CLI
+# refuses to POST an artifact whose ``edge_estimate`` cannot satisfy these
+# keys so the operator sees the mismatch locally rather than as a 422 from
+# the receiving service.
+REQUIRED_METRIC_KEYS = ("sharpe", "win_rate", "mean_return")
 
 
 def _parse_symbol_scope(raw: str) -> list[str]:
@@ -71,9 +84,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="ta_bot.cli_strategy",
         description=(
-            "Self-service strategy submission + backtest CLI (FR54-A). "
-            "Submits a strategy definition to petrosa-data-manager and/or "
-            "runs the existing backtest engine against historical data."
+            "Self-service strategy submission + backtest + characterization "
+            "+ admission CLI (FR54-A/B/C). Submits, replays, persists, and "
+            "registers strategies against the petrosa-data-manager and "
+            "petrosa-cio services."
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
@@ -154,6 +168,107 @@ def build_parser() -> argparse.ArgumentParser:
         help="HTTP timeout in seconds (default 30)",
     )
 
+    persist = sub.add_parser(
+        "persist-characterization",
+        help=(
+            "Map a CharacterizationArtifact JSON to the data-manager "
+            "Characterization shape and POST it (FR54-B AC1, #256)"
+        ),
+    )
+    persist.add_argument(
+        "--artifact-file",
+        required=True,
+        type=Path,
+        help=(
+            "Path to a CharacterizationArtifact JSON (output of "
+            "``python -m backtest`` / ``ta_bot.cli_strategy backtest``)"
+        ),
+    )
+    persist.add_argument(
+        "--strategy-version",
+        required=True,
+        help=(
+            "Strategy version tag for the persisted characterization "
+            "(forms the upsert key with strategy_id; reuse the same value "
+            "to overwrite in-place per AC3)"
+        ),
+    )
+    persist.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Deterministic RNG seed used for the backtest run (default 0)",
+    )
+    persist.add_argument(
+        "--params-file",
+        type=Path,
+        default=None,
+        help=(
+            "Optional JSON file with the parameter set used by the backtest; "
+            "feeds the canonical inputs_hash so a re-run can verify "
+            "byte-reproducibility. Defaults to ``{}`` when omitted "
+            "(strategy_revision_id remains the strong reproducibility key)."
+        ),
+    )
+    persist.add_argument(
+        "--data-manager-url",
+        default=DEFAULT_DATA_MANAGER_URL,
+        help=f"Base URL for petrosa-data-manager (default: {DEFAULT_DATA_MANAGER_URL} or $DATA_MANAGER_URL)",
+    )
+    persist.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="HTTP timeout in seconds (default 30)",
+    )
+
+    register = sub.add_parser(
+        "register-with-cio",
+        help=(
+            "POST a characterized strategy to petrosa-cio for admission "
+            "consideration (FR54-B AC2, #256)"
+        ),
+    )
+    register.add_argument(
+        "--strategy-id", required=True, help="Strategy identifier to register"
+    )
+    register.add_argument(
+        "--position-size-usd",
+        required=True,
+        type=float,
+        help="Admitted notional position size in USD (>= 0)",
+    )
+    register.add_argument(
+        "--leverage",
+        required=True,
+        type=float,
+        help="Admitted leverage (>= 1)",
+    )
+    register.add_argument(
+        "--strategy-revision-id",
+        default=None,
+        help=(
+            "FR53 / P3.4 revision id for the audit trail "
+            "(srev_{module_hash[:12]}_{parameter_hash[:12]})"
+        ),
+    )
+    register.add_argument(
+        "--submitted-by",
+        default=None,
+        help="Operator handle for the audit trail",
+    )
+    register.add_argument(
+        "--cio-url",
+        default=DEFAULT_CIO_URL,
+        help=f"Base URL for petrosa-cio (default: {DEFAULT_CIO_URL} or $CIO_URL)",
+    )
+    register.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="HTTP timeout in seconds (default 30)",
+    )
+
     return parser
 
 
@@ -169,12 +284,18 @@ def _submit_payload(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
-def _post_strategy(
+def _post_json(
     url: str,
     payload: dict[str, Any],
     timeout: float,
     opener: urllib.request.OpenerDirector | None = None,
 ) -> dict[str, Any]:
+    """POST ``payload`` as JSON and return the decoded response body.
+
+    Shared transport for ``submit``, ``persist-characterization``, and
+    ``register-with-cio`` so all three use the same urllib contract; tests
+    inject a fake opener to assert request shape.
+    """
     body = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         url,
@@ -188,13 +309,22 @@ def _post_strategy(
         status = getattr(resp, "status", None) or resp.getcode()
         text = raw.decode("utf-8") if raw else ""
         if status < 200 or status >= 300:
-            raise RuntimeError(f"Strategy submission failed: HTTP {status}: {text}")
+            raise RuntimeError(f"POST {url} failed: HTTP {status}: {text}")
         try:
             return json.loads(text) if text else {}
         except json.JSONDecodeError as exc:
             raise RuntimeError(
-                f"Strategy submission returned non-JSON response: {text!r}"
+                f"POST {url} returned non-JSON response: {text!r}"
             ) from exc
+
+
+def _post_strategy(
+    url: str,
+    payload: dict[str, Any],
+    timeout: float,
+    opener: urllib.request.OpenerDirector | None = None,
+) -> dict[str, Any]:
+    return _post_json(url, payload, timeout, opener=opener)
 
 
 def run_submit(args: argparse.Namespace) -> int:
@@ -284,6 +414,283 @@ def run_status(args: argparse.Namespace) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# FR54-B (petrosa-bot-ta-analysis#256)
+# ---------------------------------------------------------------------------
+
+
+def _compute_inputs_hash(
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    data_window_from: str,
+    data_window_to: str,
+    seed: int,
+    params: dict[str, Any],
+) -> str:
+    """Mirror ``data_manager.models.characterization.compute_inputs_hash``.
+
+    Both sides canonicalise to the same JSON shape so the persisted
+    ``inputs_hash`` is the byte-identical value the data-manager helper
+    would have computed had we used Python imports across services. The
+    CLI deliberately re-implements rather than depending on the
+    ``petrosa-data-manager`` package — ``ta-analysis`` is the producer
+    side and importing the consumer's model would couple the two
+    deployments.
+    """
+    payload = {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "data_window_from": data_window_from,
+        "data_window_to": data_window_to,
+        "seed": int(seed),
+        "params": params or {},
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _artifact_to_characterization_payload(
+    *,
+    artifact: dict[str, Any],
+    strategy_version: str,
+    seed: int,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Map a producer-side ``CharacterizationArtifact`` dict to the consumer
+    ``Characterization`` payload accepted by ``POST /api/characterizations``.
+
+    Field translation (producer → consumer):
+
+    * ``range_from`` / ``range_to`` → ``data_window_from`` / ``data_window_to``.
+    * ``edge_estimate`` → ``metrics`` with the three required keys
+      (``sharpe``, ``win_rate``, ``mean_return``) plus the extra
+      ``trade_count``; ``max_leverage_envelope`` (v1.3.0) is folded in when
+      present so the consumer's open ``metrics`` dict carries the FR3 / FR52
+      bound without a schema change.
+    * ``drawdown_envelope`` is flattened from
+      ``{p50, p90, p99, p100}`` to a 4-element list ``[p50, p90, p99, p100]``.
+    * ``sensitivity_analysis`` → ``param_sensitivities`` keyed by the
+      perturbed parameter name (producer always uses
+      ``confidence_threshold`` today).
+    * ``strategy_revision_id`` + ``strategy_revision`` pass through.
+
+    Raises :class:`ValueError` if a required producer field is missing —
+    surfacing the schema mismatch locally beats waiting for the
+    consumer's 422.
+    """
+    try:
+        strategy_id = artifact["strategy_id"]
+    except KeyError as exc:
+        raise ValueError("artifact JSON missing required key 'strategy_id'") from exc
+    try:
+        range_from = artifact["range_from"]
+        range_to = artifact["range_to"]
+    except KeyError as exc:
+        raise ValueError(f"artifact JSON missing required key {exc.args[0]!r}") from exc
+
+    edge = artifact.get("edge_estimate") or {}
+    if not edge:
+        raise ValueError(
+            "artifact JSON missing 'edge_estimate' — cannot build required metrics "
+            "(sharpe, win_rate, mean_return)"
+        )
+    # Required producer keys map to the consumer's REQUIRED_METRIC_KEYS — surface
+    # a missing one as ValueError so the CLI exits 2 cleanly rather than letting
+    # a KeyError bubble up as an opaque traceback.
+    edge_to_metric = {
+        "sharpe_ratio": "sharpe",
+        "win_rate": "win_rate",
+        "expected_pnl": "mean_return",
+    }
+    missing_edge = [k for k in edge_to_metric if k not in edge]
+    if missing_edge:
+        raise ValueError(
+            "artifact JSON 'edge_estimate' missing required key(s): "
+            + ", ".join(missing_edge)
+        )
+    metrics: dict[str, float] = {
+        "sharpe": float(edge["sharpe_ratio"]),
+        "win_rate": float(edge["win_rate"]),
+        "mean_return": float(edge["expected_pnl"]),
+        "trade_count": float(edge.get("trade_count", 0)),
+    }
+    mle = artifact.get("max_leverage_envelope")
+    if mle is not None:
+        metrics["max_leverage_envelope"] = float(mle)
+
+    dd = artifact.get("drawdown_envelope") or {}
+    if not dd:
+        raise ValueError("artifact JSON missing 'drawdown_envelope'")
+    drawdown_envelope = [
+        float(dd["p50"]),
+        float(dd["p90"]),
+        float(dd["p99"]),
+        float(dd["p100"]),
+    ]
+
+    sa = artifact.get("sensitivity_analysis") or {}
+    if sa:
+        param_sensitivities: dict[str, Any] = {
+            sa.get("parameter", "confidence_threshold"): [
+                dict(pt) for pt in sa.get("points", [])
+            ]
+        }
+    else:
+        param_sensitivities = {}
+
+    inputs_hash = _compute_inputs_hash(
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        data_window_from=range_from,
+        data_window_to=range_to,
+        seed=seed,
+        params=params,
+    )
+
+    payload: dict[str, Any] = {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "data_window_from": range_from,
+        "data_window_to": range_to,
+        "seed": int(seed),
+        "metrics": metrics,
+        "drawdown_envelope": drawdown_envelope,
+        "param_sensitivities": param_sensitivities,
+        "inputs_hash": inputs_hash,
+    }
+    revision_id = artifact.get("strategy_revision_id")
+    if revision_id is not None:
+        payload["strategy_revision_id"] = revision_id
+    revision = artifact.get("strategy_revision")
+    if revision is not None:
+        payload["strategy_revision"] = {
+            "revision_id": revision["revision_id"],
+            "module_hash": revision["module_hash"],
+            "parameter_hash": revision["parameter_hash"],
+        }
+    return payload
+
+
+def _load_artifact(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"--artifact-file {path} is not valid JSON: {exc.msg}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"--artifact-file {path} must contain a JSON object")
+    return data
+
+
+def _load_params(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"--params-file {path} is not valid JSON: {exc.msg}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"--params-file {path} must contain a JSON object")
+    return data
+
+
+def run_persist_characterization(args: argparse.Namespace) -> int:
+    if not args.artifact_file.exists():
+        print(
+            f"error: --artifact-file not found: {args.artifact_file}",
+            file=sys.stderr,
+        )
+        return 2
+    if args.params_file is not None and not args.params_file.exists():
+        print(
+            f"error: --params-file not found: {args.params_file}",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        artifact = _load_artifact(args.artifact_file)
+        params = _load_params(args.params_file)
+        payload = _artifact_to_characterization_payload(
+            artifact=artifact,
+            strategy_version=args.strategy_version,
+            seed=args.seed,
+            params=params,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    missing = [k for k in REQUIRED_METRIC_KEYS if k not in payload["metrics"]]
+    if missing:
+        print(
+            "error: artifact does not satisfy required metric keys "
+            f"({', '.join(missing)})",
+            file=sys.stderr,
+        )
+        return 2
+
+    url = args.data_manager_url.rstrip("/") + CHARACTERIZATIONS_PATH
+    try:
+        result = _post_json(url, payload, args.timeout)
+    except urllib.error.HTTPError as e:
+        try:
+            err_text = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            err_text = ""
+        print(f"error: HTTP {e.code} from {url}: {err_text}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"error: cannot reach {url}: {e.reason}", file=sys.stderr)
+        return 1
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def run_register_with_cio(args: argparse.Namespace) -> int:
+    if args.position_size_usd < 0:
+        print("error: --position-size-usd must be >= 0", file=sys.stderr)
+        return 2
+    if args.leverage < 1:
+        print("error: --leverage must be >= 1", file=sys.stderr)
+        return 2
+
+    payload: dict[str, Any] = {
+        "strategy_id": args.strategy_id,
+        "position_size_usd": float(args.position_size_usd),
+        "leverage": float(args.leverage),
+    }
+    if args.strategy_revision_id is not None:
+        payload["strategy_revision_id"] = args.strategy_revision_id
+    if args.submitted_by is not None:
+        payload["submitted_by"] = args.submitted_by
+
+    url = args.cio_url.rstrip("/") + CIO_ADMISSION_REGISTER_PATH
+    try:
+        result = _post_json(url, payload, args.timeout)
+    except urllib.error.HTTPError as e:
+        try:
+            err_text = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            err_text = ""
+        print(f"error: HTTP {e.code} from {url}: {err_text}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"error: cannot reach {url}: {e.reason}", file=sys.stderr)
+        return 1
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     raw = list(sys.argv[1:] if argv is None else argv)
     if raw and raw[0] == "backtest":
@@ -294,6 +701,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         return run_submit(args)
     if args.command == "status":
         return run_status(args)
+    if args.command == "persist-characterization":
+        return run_persist_characterization(args)
+    if args.command == "register-with-cio":
+        return run_register_with_cio(args)
     parser.print_help(sys.stderr)
     return 2
 

--- a/tests/test_cli_strategy.py
+++ b/tests/test_cli_strategy.py
@@ -531,3 +531,836 @@ def test_run_submit_returns_2_when_code_file_missing(
     assert rc == 2
     err = capsys.readouterr().err
     assert "not found" in err
+
+
+# ─── FR54-B (#256) persist-characterization + register-with-cio ─────────────
+
+
+def _sample_artifact() -> dict[str, Any]:
+    """A v1.3.0-shaped CharacterizationArtifact dict for mapping tests."""
+    return {
+        "schema_version": "1.3.0",
+        "strategy_id": "momentum-v3",
+        "symbol": "BTCUSDT",
+        "period": "1h",
+        "range_from": "2026-05-01T00:00:00+00:00",
+        "range_to": "2026-05-15T00:00:00+00:00",
+        "candle_count": 336,
+        "signal_count": 12,
+        "source": "binance",
+        "events": [],
+        "edge_estimate": {
+            "expected_pnl": 0.0123,
+            "win_rate": 0.58,
+            "sharpe_ratio": 1.42,
+            "trade_count": 12,
+        },
+        "drawdown_envelope": {
+            "p50": 0.01,
+            "p90": 0.04,
+            "p99": 0.09,
+            "p100": 0.12,
+        },
+        "sensitivity_analysis": {
+            "parameter": "confidence_threshold",
+            "points": [
+                {
+                    "confidence_threshold": 0.5,
+                    "win_rate": 0.55,
+                    "expected_pnl": 0.011,
+                    "trade_count": 14,
+                },
+                {
+                    "confidence_threshold": 0.7,
+                    "win_rate": 0.62,
+                    "expected_pnl": 0.014,
+                    "trade_count": 9,
+                },
+            ],
+        },
+        "strategy_revision_id": "srev_abc123def456_789012ghi345",
+        "strategy_revision": {
+            "revision_id": "srev_abc123def456_789012ghi345",
+            "module_hash": "a" * 64,
+            "parameter_hash": "b" * 64,
+        },
+        "max_leverage_envelope": 3.5,
+    }
+
+
+def _write_artifact(tmp_path: Path, payload: dict[str, Any] | None = None) -> Path:
+    p = tmp_path / "artifact.json"
+    p.write_text(json.dumps(payload or _sample_artifact()), encoding="utf-8")
+    return p
+
+
+def test_artifact_to_characterization_payload_maps_all_fields() -> None:
+    payload = cli_strategy._artifact_to_characterization_payload(
+        artifact=_sample_artifact(),
+        strategy_version="v1",
+        seed=7,
+        params={"window": 14},
+    )
+    assert payload["strategy_id"] == "momentum-v3"
+    assert payload["strategy_version"] == "v1"
+    assert payload["data_window_from"] == "2026-05-01T00:00:00+00:00"
+    assert payload["data_window_to"] == "2026-05-15T00:00:00+00:00"
+    assert payload["seed"] == 7
+    # metrics: required keys + carry-overs
+    assert payload["metrics"]["sharpe"] == pytest.approx(1.42)
+    assert payload["metrics"]["win_rate"] == pytest.approx(0.58)
+    assert payload["metrics"]["mean_return"] == pytest.approx(0.0123)
+    assert payload["metrics"]["trade_count"] == pytest.approx(12)
+    assert payload["metrics"]["max_leverage_envelope"] == pytest.approx(3.5)
+    # drawdown envelope flattened to ordered list
+    assert payload["drawdown_envelope"] == [0.01, 0.04, 0.09, 0.12]
+    # sensitivities re-keyed by parameter name
+    assert "confidence_threshold" in payload["param_sensitivities"]
+    assert len(payload["param_sensitivities"]["confidence_threshold"]) == 2
+    # revision binding survives
+    assert payload["strategy_revision_id"] == "srev_abc123def456_789012ghi345"
+    assert payload["strategy_revision"]["module_hash"] == "a" * 64
+    # inputs_hash is a 64-hex SHA-256 string
+    assert isinstance(payload["inputs_hash"], str)
+    assert len(payload["inputs_hash"]) == 64
+    int(payload["inputs_hash"], 16)
+
+
+def test_artifact_to_characterization_payload_deterministic_inputs_hash() -> None:
+    """Same inputs → byte-identical inputs_hash regardless of dict ordering."""
+    a = cli_strategy._artifact_to_characterization_payload(
+        artifact=_sample_artifact(),
+        strategy_version="v1",
+        seed=7,
+        params={"window": 14, "threshold": 0.03},
+    )
+    b = cli_strategy._artifact_to_characterization_payload(
+        artifact=_sample_artifact(),
+        strategy_version="v1",
+        seed=7,
+        params={"threshold": 0.03, "window": 14},
+    )
+    assert a["inputs_hash"] == b["inputs_hash"]
+
+
+def test_artifact_to_characterization_payload_changes_hash_on_seed() -> None:
+    a = cli_strategy._artifact_to_characterization_payload(
+        artifact=_sample_artifact(),
+        strategy_version="v1",
+        seed=7,
+        params={},
+    )
+    b = cli_strategy._artifact_to_characterization_payload(
+        artifact=_sample_artifact(),
+        strategy_version="v1",
+        seed=8,
+        params={},
+    )
+    assert a["inputs_hash"] != b["inputs_hash"]
+
+
+def test_artifact_to_characterization_payload_rejects_missing_edge() -> None:
+    bad = _sample_artifact()
+    bad.pop("edge_estimate")
+    with pytest.raises(ValueError, match="edge_estimate") as exc_info:
+        cli_strategy._artifact_to_characterization_payload(
+            artifact=bad, strategy_version="v1", seed=0, params={}
+        )
+    assert "edge_estimate" in str(exc_info.value)
+
+
+def test_artifact_to_characterization_payload_rejects_missing_drawdown() -> None:
+    bad = _sample_artifact()
+    bad.pop("drawdown_envelope")
+    with pytest.raises(ValueError, match="drawdown_envelope") as exc_info:
+        cli_strategy._artifact_to_characterization_payload(
+            artifact=bad, strategy_version="v1", seed=0, params={}
+        )
+    assert "drawdown_envelope" in str(exc_info.value)
+
+
+def test_artifact_to_characterization_payload_rejects_missing_strategy_id() -> None:
+    bad = _sample_artifact()
+    bad.pop("strategy_id")
+    with pytest.raises(ValueError, match="strategy_id") as exc_info:
+        cli_strategy._artifact_to_characterization_payload(
+            artifact=bad, strategy_version="v1", seed=0, params={}
+        )
+    assert "strategy_id" in str(exc_info.value)
+
+
+def test_artifact_to_characterization_payload_handles_missing_revision() -> None:
+    """v1.0–v1.1 artifacts have no strategy_revision_id; the mapper still works."""
+    legacy = _sample_artifact()
+    legacy.pop("strategy_revision_id")
+    legacy.pop("strategy_revision")
+    legacy.pop("max_leverage_envelope")
+    payload = cli_strategy._artifact_to_characterization_payload(
+        artifact=legacy, strategy_version="v1", seed=0, params={}
+    )
+    assert "strategy_revision_id" not in payload
+    assert "strategy_revision" not in payload
+    assert "max_leverage_envelope" not in payload["metrics"]
+
+
+def test_run_persist_characterization_happy_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    art_path = _write_artifact(tmp_path)
+    response_body = json.dumps(
+        {
+            "strategy_id": "momentum-v3",
+            "strategy_version": "v1",
+            "created_at": "2026-06-01T12:00:00Z",
+        }
+    ).encode("utf-8")
+    fake = _FakeOpener(_FakeResponse(201, response_body))
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: fake,
+    )
+    rc = cli_strategy.main(
+        [
+            "persist-characterization",
+            "--artifact-file",
+            str(art_path),
+            "--strategy-version",
+            "v1",
+            "--seed",
+            "7",
+            "--data-manager-url",
+            "http://dm.local/",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    printed = json.loads(out)
+    assert printed["strategy_id"] == "momentum-v3"
+    # Asserts request shape: POST to /api/characterizations with the mapped body
+    assert len(fake.requests) == 1
+    sent = fake.requests[0]
+    assert sent["url"] == "http://dm.local/api/characterizations"
+    assert sent["method"] == "POST"
+    sent_body = json.loads(sent["body"].decode("utf-8"))
+    assert sent_body["strategy_id"] == "momentum-v3"
+    assert sent_body["strategy_version"] == "v1"
+    assert sent_body["metrics"]["sharpe"] == pytest.approx(1.42)
+    assert sent_body["drawdown_envelope"] == [0.01, 0.04, 0.09, 0.12]
+    assert sent_body["strategy_revision_id"] == "srev_abc123def456_789012ghi345"
+
+
+def test_run_persist_characterization_idempotency_re_post_yields_same_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FR54-B AC3: two identical invocations produce byte-identical POSTs.
+    The data-manager upsert is keyed by (strategy_id, strategy_version), so
+    a byte-identical re-POST yields no schema/state change downstream."""
+    art_path = _write_artifact(tmp_path)
+    responses: list[_FakeResponse] = [
+        _FakeResponse(201, b'{"strategy_id":"momentum-v3"}'),
+        _FakeResponse(201, b'{"strategy_id":"momentum-v3"}'),
+    ]
+    opens: list[dict[str, Any]] = []
+
+    class _SeqOpener:
+        def __init__(self) -> None:
+            self._iter = iter(responses)
+
+        def open(self, req: Any, timeout: float = 0) -> _FakeResponse:
+            opens.append(
+                {
+                    "url": req.full_url,
+                    "method": req.get_method(),
+                    "body": req.data,
+                }
+            )
+            return next(self._iter)
+
+    seq = _SeqOpener()
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: seq,
+    )
+    argv = [
+        "persist-characterization",
+        "--artifact-file",
+        str(art_path),
+        "--strategy-version",
+        "v1",
+        "--seed",
+        "7",
+        "--data-manager-url",
+        "http://dm.local/",
+    ]
+    assert cli_strategy.main(argv) == 0
+    assert cli_strategy.main(argv) == 0
+    assert opens[0]["body"] == opens[1]["body"]
+
+
+def test_run_persist_characterization_returns_2_when_artifact_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = cli_strategy.main(
+        [
+            "persist-characterization",
+            "--artifact-file",
+            str(tmp_path / "missing.json"),
+            "--strategy-version",
+            "v1",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "not found" in err
+
+
+def test_run_persist_characterization_returns_2_when_artifact_invalid_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    rc = cli_strategy.main(
+        [
+            "persist-characterization",
+            "--artifact-file",
+            str(bad),
+            "--strategy-version",
+            "v1",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "not valid JSON" in err
+
+
+def test_run_persist_characterization_returns_2_on_missing_required_metric(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If the artifact's edge_estimate lacks fields the receiver requires
+    (sharpe/win_rate/mean_return → mapped from sharpe_ratio/win_rate/expected_pnl),
+    surface the failure locally with exit 2 before issuing the HTTP call."""
+    art = _sample_artifact()
+    # Drop a key the mapper needs to satisfy required metrics
+    art["edge_estimate"].pop("expected_pnl")
+    path = tmp_path / "art.json"
+    path.write_text(json.dumps(art), encoding="utf-8")
+    rc = cli_strategy.main(
+        [
+            "persist-characterization",
+            "--artifact-file",
+            str(path),
+            "--strategy-version",
+            "v1",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "error" in err.lower()
+
+
+def test_run_persist_characterization_handles_http_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import urllib.error as _err
+
+    art_path = _write_artifact(tmp_path)
+
+    class _ErrOpener:
+        def open(self, req: Any, timeout: float = 0) -> Any:
+            raise _err.HTTPError(
+                req.full_url, 422, "Unprocessable", {}, io.BytesIO(b"bad")
+            )
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _ErrOpener(),
+    )
+    rc = cli_strategy.main(
+        [
+            "persist-characterization",
+            "--artifact-file",
+            str(art_path),
+            "--strategy-version",
+            "v1",
+        ]
+    )
+    assert rc == 1
+    assert "HTTP 422" in capsys.readouterr().err
+
+
+def test_run_persist_characterization_handles_url_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import urllib.error as _err
+
+    art_path = _write_artifact(tmp_path)
+
+    class _ErrOpener:
+        def open(self, req: Any, timeout: float = 0) -> Any:
+            raise _err.URLError("connection refused")
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _ErrOpener(),
+    )
+    rc = cli_strategy.main(
+        [
+            "persist-characterization",
+            "--artifact-file",
+            str(art_path),
+            "--strategy-version",
+            "v1",
+        ]
+    )
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err
+
+
+def test_run_persist_characterization_loads_params_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--params-file feeds the canonical inputs_hash; same params via different
+    files must yield identical inputs_hash bytes."""
+    art_path = _write_artifact(tmp_path)
+    p1 = tmp_path / "p1.json"
+    p1.write_text('{"a": 1, "b": 2}', encoding="utf-8")
+    p2 = tmp_path / "p2.json"
+    p2.write_text('{"b": 2, "a": 1}', encoding="utf-8")
+
+    captured: list[bytes] = []
+
+    class _CapturingOpener:
+        def open(self, req: Any, timeout: float = 0) -> _FakeResponse:
+            captured.append(req.data)
+            return _FakeResponse(201, b"{}")
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _CapturingOpener(),
+    )
+    for params_file in (p1, p2):
+        cli_strategy.main(
+            [
+                "persist-characterization",
+                "--artifact-file",
+                str(art_path),
+                "--strategy-version",
+                "v1",
+                "--params-file",
+                str(params_file),
+            ]
+        )
+    body_a = json.loads(captured[0].decode("utf-8"))
+    body_b = json.loads(captured[1].decode("utf-8"))
+    assert body_a["inputs_hash"] == body_b["inputs_hash"]
+
+
+def test_run_persist_characterization_returns_2_when_params_file_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    art_path = _write_artifact(tmp_path)
+    rc = cli_strategy.main(
+        [
+            "persist-characterization",
+            "--artifact-file",
+            str(art_path),
+            "--strategy-version",
+            "v1",
+            "--params-file",
+            str(tmp_path / "missing-params.json"),
+        ]
+    )
+    assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_run_register_with_cio_happy_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    response_body = json.dumps(
+        {
+            "strategy_id": "momentum-v3",
+            "position_size_usd": 5000.0,
+            "leverage": 3.0,
+            "strategy_revision_id": "srev_abc",
+            "submitted_by": "alice",
+            "status": "admitted",
+        }
+    ).encode("utf-8")
+    fake = _FakeOpener(_FakeResponse(201, response_body))
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: fake,
+    )
+    rc = cli_strategy.main(
+        [
+            "register-with-cio",
+            "--strategy-id",
+            "momentum-v3",
+            "--position-size-usd",
+            "5000",
+            "--leverage",
+            "3",
+            "--strategy-revision-id",
+            "srev_abc",
+            "--submitted-by",
+            "alice",
+            "--cio-url",
+            "http://cio.local/",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    printed = json.loads(out)
+    assert printed["status"] == "admitted"
+    assert len(fake.requests) == 1
+    sent = fake.requests[0]
+    assert sent["url"] == "http://cio.local/api/admission/register"
+    assert sent["method"] == "POST"
+    body = json.loads(sent["body"].decode("utf-8"))
+    assert body == {
+        "strategy_id": "momentum-v3",
+        "position_size_usd": 5000.0,
+        "leverage": 3.0,
+        "strategy_revision_id": "srev_abc",
+        "submitted_by": "alice",
+    }
+
+
+def test_run_register_with_cio_idempotency_byte_identical_resends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FR54-B AC3: re-register with the same args → byte-identical request body.
+    PortfolioTracker.record_admit replaces the per-strategy entry in a dict,
+    so two byte-identical POSTs leave portfolio state unchanged after the
+    second."""
+    opens: list[bytes] = []
+
+    class _CapOpener:
+        def open(self, req: Any, timeout: float = 0) -> _FakeResponse:
+            opens.append(req.data)
+            return _FakeResponse(201, b'{"status":"admitted"}')
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _CapOpener(),
+    )
+    argv = [
+        "register-with-cio",
+        "--strategy-id",
+        "x",
+        "--position-size-usd",
+        "100",
+        "--leverage",
+        "2",
+    ]
+    assert cli_strategy.main(argv) == 0
+    assert cli_strategy.main(argv) == 0
+    assert opens[0] == opens[1]
+
+
+def test_run_register_with_cio_omits_optional_fields() -> None:
+    """When --strategy-revision-id/--submitted-by are absent the keys are
+    NOT sent (rather than null) so the CIO Pydantic model uses its
+    field defaults."""
+    fake = _FakeOpener(_FakeResponse(201, b'{"status":"admitted"}'))
+    args = cli_strategy.build_parser().parse_args(
+        [
+            "register-with-cio",
+            "--strategy-id",
+            "x",
+            "--position-size-usd",
+            "100",
+            "--leverage",
+            "2",
+        ]
+    )
+    # Call run_register_with_cio directly with a monkey-patched build_opener
+    import urllib.request as _ur
+
+    orig = _ur.build_opener
+    _ur.build_opener = lambda *a, **kw: fake  # type: ignore[assignment]
+    try:
+        rc = cli_strategy.run_register_with_cio(args)
+    finally:
+        _ur.build_opener = orig
+    assert rc == 0
+    sent_body = json.loads(fake.requests[0]["body"].decode("utf-8"))
+    assert "strategy_revision_id" not in sent_body
+    assert "submitted_by" not in sent_body
+
+
+def test_run_register_with_cio_validates_position_size_negative(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = cli_strategy.main(
+        [
+            "register-with-cio",
+            "--strategy-id",
+            "x",
+            "--position-size-usd",
+            "-1",
+            "--leverage",
+            "2",
+        ]
+    )
+    assert rc == 2
+    assert ">= 0" in capsys.readouterr().err
+
+
+def test_run_register_with_cio_validates_leverage_below_one(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = cli_strategy.main(
+        [
+            "register-with-cio",
+            "--strategy-id",
+            "x",
+            "--position-size-usd",
+            "100",
+            "--leverage",
+            "0.5",
+        ]
+    )
+    assert rc == 2
+    assert ">= 1" in capsys.readouterr().err
+
+
+def test_run_register_with_cio_handles_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import urllib.error as _err
+
+    class _ErrOpener:
+        def open(self, req: Any, timeout: float = 0) -> Any:
+            raise _err.HTTPError(
+                req.full_url, 503, "tracker missing", {}, io.BytesIO(b"down")
+            )
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _ErrOpener(),
+    )
+    rc = cli_strategy.main(
+        [
+            "register-with-cio",
+            "--strategy-id",
+            "x",
+            "--position-size-usd",
+            "100",
+            "--leverage",
+            "2",
+        ]
+    )
+    assert rc == 1
+    assert "HTTP 503" in capsys.readouterr().err
+
+
+def test_run_register_with_cio_handles_url_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import urllib.error as _err
+
+    class _ErrOpener:
+        def open(self, req: Any, timeout: float = 0) -> Any:
+            raise _err.URLError("connection refused")
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _ErrOpener(),
+    )
+    rc = cli_strategy.main(
+        [
+            "register-with-cio",
+            "--strategy-id",
+            "x",
+            "--position-size-usd",
+            "100",
+            "--leverage",
+            "2",
+        ]
+    )
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err
+
+
+def test_run_register_with_cio_handles_non_json_response(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake = _FakeOpener(_FakeResponse(201, b"not-json"))
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: fake,
+    )
+    rc = cli_strategy.main(
+        [
+            "register-with-cio",
+            "--strategy-id",
+            "x",
+            "--position-size-usd",
+            "100",
+            "--leverage",
+            "2",
+        ]
+    )
+    assert rc == 1
+    assert "non-JSON" in capsys.readouterr().err
+
+
+# ─── AC4 — end-to-end FR54-A → FR54-B chain ─────────────────────────────────
+
+
+def test_fr54_b_end_to_end_persist_then_register(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC4 — end-to-end test:
+    1. Persist a CharacterizationArtifact via persist-characterization.
+    2. Register the same strategy with CIO via register-with-cio.
+    3. Both records exist and the strategy_revision_id is bound across them.
+    4. Re-running both is a no-op (byte-identical request bodies).
+    """
+    art_path = _write_artifact(tmp_path)
+    # Two routing buckets keyed by host: data-manager and cio. The fake opener
+    # routes each request to the correct response bucket and records both for
+    # cross-record consistency assertions.
+    dm_responses: list[_FakeResponse] = [
+        _FakeResponse(201, b'{"strategy_id":"momentum-v3","strategy_version":"v1"}'),
+        _FakeResponse(201, b'{"strategy_id":"momentum-v3","strategy_version":"v1"}'),
+    ]
+    cio_responses: list[_FakeResponse] = [
+        _FakeResponse(201, b'{"strategy_id":"momentum-v3","status":"admitted"}'),
+        _FakeResponse(201, b'{"strategy_id":"momentum-v3","status":"admitted"}'),
+    ]
+    dm_recorded: list[bytes] = []
+    cio_recorded: list[bytes] = []
+
+    class _RoutingOpener:
+        def open(self, req: Any, timeout: float = 0) -> _FakeResponse:
+            url = req.full_url
+            if "/api/characterizations" in url:
+                dm_recorded.append(req.data)
+                return dm_responses.pop(0)
+            if "/api/admission/register" in url:
+                cio_recorded.append(req.data)
+                return cio_responses.pop(0)
+            raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(
+        cli_strategy.urllib.request,
+        "build_opener",
+        lambda *a, **kw: _RoutingOpener(),
+    )
+
+    # Step 1: persist
+    rc1 = cli_strategy.main(
+        [
+            "persist-characterization",
+            "--artifact-file",
+            str(art_path),
+            "--strategy-version",
+            "v1",
+            "--seed",
+            "7",
+            "--data-manager-url",
+            "http://dm.local/",
+        ]
+    )
+    assert rc1 == 0
+
+    # Step 2: register with CIO using the artifact's revision id
+    artifact = json.loads(art_path.read_text(encoding="utf-8"))
+    rc2 = cli_strategy.main(
+        [
+            "register-with-cio",
+            "--strategy-id",
+            artifact["strategy_id"],
+            "--position-size-usd",
+            "5000",
+            "--leverage",
+            "3",
+            "--strategy-revision-id",
+            artifact["strategy_revision_id"],
+            "--submitted-by",
+            "alice",
+            "--cio-url",
+            "http://cio.local/",
+        ]
+    )
+    assert rc2 == 0
+
+    # Both records were emitted
+    assert len(dm_recorded) == 1
+    assert len(cio_recorded) == 1
+
+    # Bound to the same strategy revision id across services
+    dm_body = json.loads(dm_recorded[0].decode("utf-8"))
+    cio_body = json.loads(cio_recorded[0].decode("utf-8"))
+    assert (
+        dm_body["strategy_revision_id"]
+        == cio_body["strategy_revision_id"]
+        == "srev_abc123def456_789012ghi345"
+    )
+    assert dm_body["strategy_id"] == cio_body["strategy_id"] == "momentum-v3"
+
+    # Step 3 — AC3 idempotency: re-run both, expect byte-identical request bodies
+    rc3 = cli_strategy.main(
+        [
+            "persist-characterization",
+            "--artifact-file",
+            str(art_path),
+            "--strategy-version",
+            "v1",
+            "--seed",
+            "7",
+            "--data-manager-url",
+            "http://dm.local/",
+        ]
+    )
+    rc4 = cli_strategy.main(
+        [
+            "register-with-cio",
+            "--strategy-id",
+            artifact["strategy_id"],
+            "--position-size-usd",
+            "5000",
+            "--leverage",
+            "3",
+            "--strategy-revision-id",
+            artifact["strategy_revision_id"],
+            "--submitted-by",
+            "alice",
+            "--cio-url",
+            "http://cio.local/",
+        ]
+    )
+    assert rc3 == 0
+    assert rc4 == 0
+    assert dm_recorded[0] == dm_recorded[1]
+    assert cio_recorded[0] == cio_recorded[1]


### PR DESCRIPTION
## Summary

Implements **FR54-B** of P5.3 (PetroSa2/petrosa-bot-ta-analysis#256):
characterization persistence + CIO admission registration. Closes #256.

After a backtest completes (via FR54-A, shipped in #258), two new CLI
subcommands bind the resulting characterization artifact to the
strategy's content-addressable revision (per FR53 / P3.4, shipped in
#250) and register the characterized strategy with `petrosa-cio` for
admission consideration (per FR5).

## What changed

* `ta_bot/cli_strategy.py` gains two subcommands and one shared helper:
  * **`persist-characterization`** (AC1) — maps a
    `CharacterizationArtifact` JSON produced by `ta_bot.cli_strategy
    backtest` into the data-manager `Characterization` payload and
    POSTs to `POST /api/characterizations`. Carries the artifact's
    `strategy_revision_id` + `strategy_revision` through so the
    consumer-side P3.4 binding (data-manager #179) lights up
    automatically. `--params-file` optionally feeds the canonical
    `inputs_hash` so a re-run can verify byte-reproducibility.
  * **`register-with-cio`** (AC2) — POSTs to `POST
    /api/admission/register` on `petrosa-cio` (PetroSa2/petrosa-cio
    #156). Optional `--strategy-revision-id` / `--submitted-by` flow
    into the audit trail; absent optionals are omitted rather than
    sent as `null` so the cio Pydantic model uses its field defaults.
  * `_post_json` consolidates the urllib transport contract shared by
    `submit`, `persist-characterization`, and `register-with-cio`.

* `_artifact_to_characterization_payload` translates producer → consumer
  shape with explicit `ValueError`s on schema mismatch (exit 2) so the
  operator sees the failure locally rather than as a 422 from the
  receiving service.

## Acceptance criteria

* **AC1 — Characterization persistence:** `persist-characterization`
  registers the backtest output via the data-manager
  characterization store, bound to the strategy's content-addressable
  revision.
* **AC2 — CIO admission registration:** `register-with-cio` registers
  the characterized strategy with `petrosa-cio` for admission
  consideration through a CLI subcommand.
* **AC3 — Idempotency:** native on both sides — data-manager upserts
  characterizations by `(strategy_id, strategy_version)`;
  `PortfolioTracker.record_admit` replaces the per-strategy entry in a
  dict. Re-running both subcommands with the same args yields
  byte-identical request bodies (asserted in tests).
* **AC4 — Integration test:**
  `test_fr54_b_end_to_end_persist_then_register` chains
  `persist-characterization` → `register-with-cio` → replay, asserts
  both records exist, bind to the same `strategy_revision_id`, and
  re-invocations are byte-identical.

## Testing

* `tests/test_cli_strategy.py` — 46 tests pass (25 new for FR54-B
  covering the mapper, idempotency, error paths, and the AC4 chain).
* `uv run pytest tests/unit/` — 173 tests pass, no regressions.
* `uv run ruff check ta_bot/cli_strategy.py tests/test_cli_strategy.py` — clean.
* `uv run mypy ta_bot/cli_strategy.py` — clean. The 120 mypy errors
  surfaced by `make pipeline` on `ta_bot/` are pre-existing on `main`
  (106 before this branch, +14 from changed-import re-analysis in
  unrelated files; my new code is mypy-clean).

## References

* Parent: petrosa-data-manager#171 (P5.3 / FR54)
* ADR: petrosa_k8s `docs/decisions/fr54-host-service.md` (merged via #764)
* Sibling stories: **FR54-A** (#258, prerequisite — merged), **FR54-C** (#259, partial — merged)
* Producer-side revision binding: petrosa-bot-ta-analysis#250 (FR53 / P3.4)
* Consumer-side revision binding: petrosa-data-manager#179
* CIO admission HTTP surface: petrosa-cio#156

Closes #256.
