### PR TITLE
fix: reword misleading MySQL reason strings in health evaluator (petrosa_k8s#823)

### DIFF
--- a/ta_bot/evaluators/health_evaluator.py
+++ b/ta_bot/evaluators/health_evaluator.py
@@ -10,10 +10,10 @@ signal publisher) on each emit tick:
 
 1. **Indicator-compute latency** — rolling mean of the per-extraction
    ``analyze_candles`` duration. A sustained high value means the strategy
-   computation is degrading (slow MySQL reads, CPU starvation, etc.).
-2. **MySQL connection health** — whether the most recent candle-data fetch
-   succeeded. Repeated fetch failures mean the candle source (direct MySQL or
-   the Data Manager fronting it) is unreachable, so no analysis can run.
+   computation is degrading (slow candle-data reads, CPU starvation, etc.).
+2. **Candle-data connection health** — whether the most recent candle-data fetch
+   succeeded. Repeated fetch failures mean the candle source (data-manager API)
+   is unreachable, so no analysis can run.
 3. **Signal-emission rate** — outbound signal count. TA signals are sparse
    (emitted only on candle-close extraction events), so the collapse check
    stays dormant until a meaningful emission baseline is established; it then
@@ -182,9 +182,9 @@ class BotTaAnalysisHealthEvaluator(Evaluator):
         if not nats_connected:
             return "unhealthy", "NATS publisher disconnected; cannot emit signals"
 
-        # 2) MySQL / candle-data connection health.
+        # 2) Candle-data / Data Manager connection health.
         if not mysql_healthy:
-            return "unhealthy", "candle-data source unreachable (MySQL/Data Manager)"
+            return "unhealthy", "candle-data source unreachable (data-manager API)"
 
         # 3) Indicator-compute latency.
         if latency_s > self._latency_threshold_s:
@@ -216,7 +216,7 @@ class BotTaAnalysisHealthEvaluator(Evaluator):
 
         return (
             "healthy",
-            f"compute {latency_s:.2f}s, {signal_rate:.3f} signals/s, MySQL ok",
+            f"compute {latency_s:.2f}s, {signal_rate:.3f} signals/s, candle-data ok",
         )
 
 

--- a/tests/unit/test_health_evaluator.py
+++ b/tests/unit/test_health_evaluator.py
@@ -78,7 +78,7 @@ async def test_healthy_when_connected_and_ok(clock):
     await ev.evaluate()
     verdict, reason = await ev.evaluate()
     assert verdict == "healthy"
-    assert "MySQL ok" in reason
+    assert "candle-data ok" in reason
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Rewrites the misleading `"MySQL"` / `"Data Manager"` reason strings in `BotTaAnalysisHealthEvaluator` so operators don't misread an evaluator-unhealthy Telegram alert as a DB write failure.

## Investigation findings (AC1–AC2, PetroSa2/petrosa_k8s#823)

**Root cause of 2026-06-10 flapping:**
- **bot-ta-analysis (6 alerts):** Reason #2 (`candle-data source unreachable`) triggered transiently while the P0 Atlas quota breach (#819) caused intermittent data-manager API failures. The string `"MySQL/Data Manager"` in the alert text led the operator to classify it as a DB write failure.
- **cio (4 alerts):** `"reasoning-context missing on X%"` triggered by the LLM returning 503 during #824 (now fixed via cio PR #162). No MySQL mention in cio evaluator — no code change needed there.

## Changes (AC4)

| File | Old string | New string |
|---|---|---|
| `health_evaluator.py:187` | `"candle-data source unreachable (MySQL/Data Manager)"` | `"candle-data source unreachable (data-manager API)"` |
| `health_evaluator.py:219` | `"... signals/s, MySQL ok"` | `"... signals/s, candle-data ok"` |
| `test_health_evaluator.py:81` | `assert "MySQL ok" in reason` | `assert "candle-data ok" in reason` |

## AC3 — Remediation decisions

- **NATS disconnect:** No current incidents; no new ticket needed.
- **candle-data unreachable (reason #2):** Root cause was P0 quota breach (#819/dm#219-221, resolved). AC4 (this PR) removes the misleading string. No further remediation needed.
- **signal collapse (reason #4):** Hypothesis: SIGNAL_DEDUPLICATED reducing emission rate below baseline. Separate investigation deferred — not evidenced in current logs.
- **cio reasoning-context:** #824 fixed. Threshold tuning deferred if re-observed.

## Test results

- 743 passed, 5 skipped — no regressions
- Pre-existing 120 mypy errors in unrelated files (`config_routes.py`, `health.py`) are not introduced by this PR (verified on `main`)

Closes PetroSa2/petrosa_k8s#823
